### PR TITLE
Try using an interface instead

### DIFF
--- a/src/AbstractRegistryFormat.php
+++ b/src/AbstractRegistryFormat.php
@@ -12,6 +12,7 @@ namespace Joomla\Registry;
  * Abstract Format for Registry
  *
  * @since  1.0
+ * @deprecated  2.0  You should implement the RegistryFormatInterface in Formats
  */
 abstract class AbstractRegistryFormat
 {
@@ -30,6 +31,7 @@ abstract class AbstractRegistryFormat
 	 * @return  AbstractRegistryFormat  Registry format handler
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  Use Registry->getFormat($type) instead
 	 * @throws  \InvalidArgumentException
 	 */
 	public static function getInstance($type)

--- a/src/Format/Ini.php
+++ b/src/Format/Ini.php
@@ -8,7 +8,7 @@
 
 namespace Joomla\Registry\Format;
 
-use Joomla\Registry\AbstractRegistryFormat;
+use Joomla\Registry\RegistryFormatInterface;
 use stdClass;
 
 /**
@@ -16,7 +16,7 @@ use stdClass;
  *
  * @since  1.0
  */
-class Ini extends AbstractRegistryFormat
+class Ini implements RegistryFormatInterface
 {
 	/**
 	 * A cache used by stringToobject.

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -8,14 +8,16 @@
 
 namespace Joomla\Registry\Format;
 
+use Joomla\Registry\Registry;
 use Joomla\Registry\AbstractRegistryFormat;
+use Joomla\Registry\RegistryFormatInterface;
 
 /**
  * JSON format handler for Registry.
  *
  * @since  1.0
  */
-class Json extends AbstractRegistryFormat
+class Json implements RegistryFormatInterface
 {
 	/**
 	 * Converts an object into a JSON formatted string.
@@ -50,7 +52,7 @@ class Json extends AbstractRegistryFormat
 
 		if ((substr($data, 0, 1) != '{') && (substr($data, -1, 1) != '}'))
 		{
-			$ini = AbstractRegistryFormat::getInstance('Ini');
+			$ini = new Ini;
 			$obj = $ini->stringToObject($data, $options);
 		}
 		else

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Registry\Format;
 
-use Joomla\Registry\Registry;
-use Joomla\Registry\AbstractRegistryFormat;
 use Joomla\Registry\RegistryFormatInterface;
 
 /**

--- a/src/Format/Php.php
+++ b/src/Format/Php.php
@@ -8,14 +8,14 @@
 
 namespace Joomla\Registry\Format;
 
-use Joomla\Registry\AbstractRegistryFormat;
+use Joomla\Registry\RegistryFormatInterface;
 
 /**
  * PHP class format handler for Registry
  *
  * @since  1.0
  */
-class Php extends AbstractRegistryFormat
+class Php implements RegistryFormatInterface
 {
 	/**
 	 * Converts an object into a php class string.

--- a/src/Format/Xml.php
+++ b/src/Format/Xml.php
@@ -8,7 +8,7 @@
 
 namespace Joomla\Registry\Format;
 
-use Joomla\Registry\AbstractRegistryFormat;
+use Joomla\Registry\RegistryFormatInterface;
 use SimpleXMLElement;
 use stdClass;
 
@@ -17,7 +17,7 @@ use stdClass;
  *
  * @since  1.0
  */
-class Xml extends AbstractRegistryFormat
+class Xml implements RegistryFormatInterface
 {
 	/**
 	 * Converts an object into an XML formatted string.

--- a/src/Format/Yaml.php
+++ b/src/Format/Yaml.php
@@ -8,7 +8,7 @@
 
 namespace Joomla\Registry\Format;
 
-use Joomla\Registry\AbstractRegistryFormat;
+use Joomla\Registry\RegistryFormatInterface;
 use Symfony\Component\Yaml\Parser as SymfonyYamlParser;
 use Symfony\Component\Yaml\Dumper as SymfonyYamlDumper;
 
@@ -17,7 +17,7 @@ use Symfony\Component\Yaml\Dumper as SymfonyYamlDumper;
  *
  * @since  1.0
  */
-class Yaml extends AbstractRegistryFormat
+class Yaml implements RegistryFormatInterface
 {
 	/**
 	 * The YAML parser class.

--- a/src/RegistryFormatInterface.php
+++ b/src/RegistryFormatInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Part of the Joomla Framework Registry Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Registry;
+
+/**
+ * Abstract Format for Registry
+ *
+ * @since  1.0
+ */
+interface RegistryFormatInterface
+{
+	/**
+	 * Converts an object into a formatted string.
+	 *
+	 * @param   object  $object   Data Source Object.
+	 * @param   array   $options  An array of options for the formatter.
+	 *
+	 * @return  string  Formatted string.
+	 *
+	 * @since   1.0
+	 */
+	public function objectToString($object, $options = null);
+
+	/**
+	 * Converts a formatted string into an object.
+	 *
+	 * @param   string  $data     Formatted string
+	 * @param   array   $options  An array of options for the formatter.
+	 *
+	 * @return  object  Data Object
+	 *
+	 * @since   1.0
+	 */
+	public function stringToObject($data, array $options = array());
+}


### PR DESCRIPTION
So this replaces the Abstract Registry Format with an interface. As I think that's a better option. It deprecates that class and gives a getFormat and setFormat function in the Registry itself.

It allows for people to add their own extra formats if they want (currently impossible unless you put it in the Joomla namespace because of how the AbstractRegistryFormat::getInstance() function works).

However slight disadvantages do exist namely
1. We now have to call INI directly in the JSON format class (though not sure this is a big issue)
2. There is now one format class set up per Registry instance rather than just overall