### PR TITLE
Fix get() method to find numeric array indexes

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -182,9 +182,14 @@ class Registry implements \JsonSerializable, \ArrayAccess
 		// Traverse the registry to find the correct node for the result.
 		foreach ($nodes as $n)
 		{
-			if (isset($node->$n))
+			if (is_object($node) && isset($node->$n))
 			{
 				$node = $node->$n;
+				$found = true;
+			}
+			else if (is_array($node) && isset($node[$n])) 
+			{
+				$node = $node[$n];
 				$found = true;
 			}
 			else


### PR DESCRIPTION
In current version the registry does not find any numeric indexes of arrays.
E. g. $registry->get('key.key2.0.value'); does not return anything;
