### PR TITLE
Json encoding options implemented

### DIFF
--- a/Tests/format/FormatJsonTest.php
+++ b/Tests/format/FormatJsonTest.php
@@ -53,74 +53,79 @@ class JRegistryFormatJSONTest extends \PHPUnit_Framework_TestCase
 			$this->equalTo($string)
 		);
 	}
-  /**
-   * Test the Json::objectToString method with different options.
-   *
-   * @return  void
-   *
-   * @since   1.0
-   */
-  public function testObjectToStringOptions()
-  {
-    $class = AbstractRegistryFormat::getInstance('JSON');
-        
-    $object1 = new \stdClass;
-    $object1->specialchars = '<a href="http://example.com/?test1=10&test2=20" target=\'_blank\'>Anchor</a>';
-    $string1 = "{\"specialchars\":\"\u003Ca href=\u0022http:\/\/example.com\/?test1=10\u0026test2=20\u0022 target=\u0027_blank\u0027\u003EAnchor\u003C\/a\u003E\"}";
-    
-    $object2 = new \stdClass;
-    $object2->array = array(1, 2, 3);
-    $string2 = "{\"array\":{\"0\":1,\"1\":2,\"2\":3}}";
-    
-    $object3 = new \stdClass;
-    $object3->utf8 = 'Строка в кириллице';
-    $string3 = "{\"utf8\":\"\u0421\u0442\u0440\u043e\u043a\u0430 \u0432 \u043a\u0438\u0440\u0438\u043b\u043b\u0438\u0446\u0435\"}";
-    
-    $object4 = new \stdClass;
-    $object4->integer = "123456";    
-    $string4 = "{\"integer\":123456}";
-    
-    $object5 = new \stdClass;
-    $object5->pretty = array("key"=>"value"); 
-    $string5 = "{\n    \"pretty\": {\n        \"key\": \"value\"\n    }\n}";
-    
-    $object6 = new \stdClass;
-    $object6->slashes = "host/test\\value"; 
-    $string6 = "{\"slashes\":\"host/test\\\\value\"}";
-    
-    $this->assertThat(
-      $class->objectToString($object1, array('hex_tag'=>true, 'hex_amp'=>true, 'hex_apos'=>true, 'hex_quot'=>true)),
-      $this->equalTo($string1),
-      'Line:' . __LINE__ . ' Special characters should be converted to unicode sequences.'
-    );
-    $this->assertThat(
-      $class->objectToString($object2, array('force_object'=>true)),
-      $this->equalTo($string2),
-      'Line:' . __LINE__ . ' Arrays should be saved as objects.'
-    );
-    $this->assertThat(
-      $class->objectToString($object3, array('unescaped_unicode'=>false)),
-      $this->equalTo($string3),
-      'Line:' . __LINE__ . ' Unicode characters should be saved as unicode sequences.'
-    );
-    $this->assertThat(
-      $class->objectToString($object4, array('numeric_check'=>true)),
-      $this->equalTo($string4),
-      'Line:' . __LINE__ . ' Strings containing numbers should be saved as numbers.'
-    );
-    $this->assertThat(
-      $class->objectToString($object5, array('pretty_print'=>true)),
-      $this->equalTo($string5),
-      'Line:' . __LINE__ . ' JSON should be idented and spaced.'
-    );
-    $this->assertThat(
-      $class->objectToString($object6, array('unescaped_slashes'=>true)),
-      $this->equalTo($string6),
-      'Line:' . __LINE__ . ' Slashes should not be escaped.'
-    );
-    
-  }
-  
+	/**
+	 * Test the Json::objectToString method with different options.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testObjectToStringOptions()
+	{
+		$class = AbstractRegistryFormat::getInstance('JSON');
+
+		$object1 = new \stdClass;
+		$object1->specialchars = '<a href="http://example.com/?test1=10&test2=20" target=\'_blank\'>Anchor</a>';
+		$string1 = "{\"specialchars\":\"\u003Ca href=\u0022http:\/\/example.com\/?test1=10\u0026test2=20\u0022 target=\u0027_blank\u0027\u003EAnchor\u003C\/a\u003E\"}";
+
+		$object2 = new \stdClass;
+		$object2->array = array(1, 2, 3);
+		$string2 = "{\"array\":{\"0\":1,\"1\":2,\"2\":3}}";
+
+		$object3 = new \stdClass;
+		$object3->utf8 = 'Строка в кириллице';
+		$string3 = "{\"utf8\":\"\u0421\u0442\u0440\u043e\u043a\u0430 \u0432 \u043a\u0438\u0440\u0438\u043b\u043b\u0438\u0446\u0435\"}";
+
+		$object4 = new \stdClass;
+		$object4->integer = "123456";
+		$string4 = "{\"integer\":123456}";
+
+		$object5 = new \stdClass;
+		$object5->pretty = array("key"=>"value"); 
+		$string5 = "{\n    \"pretty\": {\n        \"key\": \"value\"\n    }\n}";
+
+		$object6 = new \stdClass;
+		$object6->slashes = "host/test\\value"; 
+		$string6 = "{\"slashes\":\"host/test\\\\value\"}";
+
+		$this->assertThat(
+			$class->objectToString($object1, array('hex_tag'=>true, 'hex_amp'=>true, 'hex_apos'=>true, 'hex_quot'=>true)),
+			$this->equalTo($string1),
+			'Line:' . __LINE__ . ' Special characters should be converted to unicode sequences.'
+		);
+
+		$this->assertThat(
+			$class->objectToString($object2, array('force_object'=>true)),
+			$this->equalTo($string2),
+			'Line:' . __LINE__ . ' Arrays should be saved as objects.'
+		);
+
+		$this->assertThat(
+			$class->objectToString($object3, array('unescaped_unicode'=>false)),
+			$this->equalTo($string3),
+			'Line:' . __LINE__ . ' Unicode characters should be saved as unicode sequences.'
+		);
+
+		$this->assertThat(
+			$class->objectToString($object4, array('numeric_check'=>true)),
+			$this->equalTo($string4),
+			'Line:' . __LINE__ . ' Strings containing numbers should be saved as numbers.'
+		);
+
+		$this->assertThat(
+			$class->objectToString($object5, array('pretty_print'=>true)),
+			$this->equalTo($string5),
+			'Line:' . __LINE__ . ' JSON should be idented and spaced.'
+		);
+
+		$this->assertThat(
+			$class->objectToString($object6, array('unescaped_slashes'=>true)),
+			$this->equalTo($string6),
+			'Line:' . __LINE__ . ' Slashes should not be escaped.'
+		);
+		
+	}
+
 	/**
 	 * Test the Json::stringToObject method.
 	 *

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -19,22 +19,23 @@ use Joomla\Utilities\JsonHelper;
  */
 class Json extends AbstractRegistryFormat
 {
-  /**
-   * Default set of options for JSON encoding
-   * @var     array
-   * @since   1.0
-   */
-  protected $options = array(
-    'hex_tag'=>false,
-    'hex_amp'=>false,
-    'hex_apos'=>false,
-    'hex_quot'=>false,
-    'force_object'=>false,
-    'numeric_check'=>false,
-    'pretty_print'=>false,
-    'unescaped_slashes'=>false,
-    'unescaped_unicode'=>false
-  );
+	/**
+	 * Default set of options for JSON encoding
+	 * @var     array
+	 * @since   1.0
+	 */
+
+	protected $options = array(
+		'hex_tag'=>false,
+		'hex_amp'=>false,
+		'hex_apos'=>false,
+		'hex_quot'=>false,
+		'force_object'=>false,
+		'numeric_check'=>false,
+		'pretty_print'=>false,
+		'unescaped_slashes'=>false,
+		'unescaped_unicode'=>false
+	);
 	/**
 	 * Converts an object into a JSON formatted string.
 	 *
@@ -50,44 +51,45 @@ class Json extends AbstractRegistryFormat
 	  $options = array_merge($this->options, (array) $options);
 	  $encode_options = 0;
 
-    //Options below are supported since PHP 5.3.0
-	  if ($options['hex_tag']) $encode_options |= JSON_HEX_TAG;
-	  if ($options['hex_amp']) $encode_options |= JSON_HEX_AMP;
-	  if ($options['hex_apos']) $encode_options |= JSON_HEX_APOS;
-	  if ($options['hex_quot']) $encode_options |= JSON_HEX_QUOT;
-	  if ($options['force_object']) $encode_options |= JSON_FORCE_OBJECT;
-	  if ($options['numeric_check'])  $encode_options |= JSON_NUMERIC_CHECK;
+		//Options below are supported since PHP 5.3.0
+		if ($options['hex_tag']) $encode_options |= JSON_HEX_TAG;
+		if ($options['hex_amp']) $encode_options |= JSON_HEX_AMP;
+		if ($options['hex_apos']) $encode_options |= JSON_HEX_APOS;
+		if ($options['hex_quot']) $encode_options |= JSON_HEX_QUOT;
+		if ($options['force_object']) $encode_options |= JSON_FORCE_OBJECT;
+		if ($options['numeric_check']) $encode_options |= JSON_NUMERIC_CHECK;
 
 
-    if (version_compare(PHP_VERSION, '5.4.0', '>='))
-    {
-      //Options below are supported since PHP 5.4.0
-      if ($options['pretty_print'])       $encode_options |= JSON_PRETTY_PRINT;
-      if ($options['unescaped_slashes'])  $encode_options |= JSON_UNESCAPED_SLASHES;
-      if ($options['unescaped_unicode'])  $encode_options |= JSON_UNESCAPED_UNICODE;
-      
-    }
-    
-    $result = json_encode($object, $encode_options);
-    
-    if (version_compare(PHP_VERSION, '5.4.0', '<')) 
-    {
-        if ($options['pretty_print'])
-        {
-          $result = JsonHelper::prettify($result, '    ');
-        }
-        if ($options['unescaped_unicode'])
-        {
-          $result = String::unicode_to_utf8($result);
-        }
-        if ($options['unescaped_slashes'])
-        {
-          $result = str_replace("\\/", "/", $result);
-        }  
-    }
+		if (version_compare(PHP_VERSION, '5.4.0', '>='))
+		{
+			//Options below are supported since PHP 5.4.0
+			if ($options['pretty_print']) $encode_options |= JSON_PRETTY_PRINT;
+			if ($options['unescaped_slashes']) $encode_options |= JSON_UNESCAPED_SLASHES;
+			if ($options['unescaped_unicode']) $encode_options |= JSON_UNESCAPED_UNICODE;
+			
+		}
 
-    return $result;
-    
+		$result = json_encode($object, $encode_options);
+		
+		if (version_compare(PHP_VERSION, '5.4.0', '<')) 
+		{
+			if ($options['pretty_print'])
+			{
+				//Use 4 spaces to emulate JSON_PRETTY_PRINT behavior
+				$result = JsonHelper::prettify($result, '    ');
+			}
+			if ($options['unescaped_unicode'])
+			{
+				$result = String::unicode_to_utf8($result);
+			}
+			if ($options['unescaped_slashes'])
+			{
+				$result = str_replace("\\/", "/", $result);
+			}
+		}
+
+		return $result;
+
 	}
 
 	/**


### PR DESCRIPTION
Options are similiar to constants listed here: http://php.net/manual/en/json.constants.php which are appliable to `json_encode` function.
Some functions are unavailable in PHP below 5.4 so there are replaces for them.

Uses JsonHelper class from https://github.com/joomla-framework/utilities/pull/3
