### PR TITLE
Make the Registry object iterable and countable

### DIFF
--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -186,6 +186,24 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the behavior of the \Countable interface implementation
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Registry\Registry::count
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testCountable()
+	{
+		$a = new Registry;
+		$a->set('foo1', 'testtoarray1');
+		$a->set('foo2', 'testtoarray2');
+		$a->set('config.foo3', 'testtoarray3');
+
+		$this->assertEquals(3, count($a), 'count() should correctly count the number of data elements.');
+	}
+
+	/**
 	 * Test the Joomla\Registry\Registry::exists method.
 	 *
 	 * @return  void
@@ -282,6 +300,20 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 			$this->logicalNot($this->identicalTo($c)),
 			'Line: ' . __LINE__ . '.'
 		);
+	}
+
+	/**
+	 * Tests the Joomla\Registry\Registry::getIterator method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Registry\Registry::getIterator
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testGetIterator()
+	{
+		$a = new Registry;
+		$this->assertInstanceOf('ArrayIterator', $a->getIterator());
 	}
 
 	/**

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -15,7 +15,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.0
  */
-class Registry implements \JsonSerializable, \ArrayAccess
+class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \Countable
 {
 	/**
 	 * Registry Object
@@ -78,6 +78,26 @@ class Registry implements \JsonSerializable, \ArrayAccess
 	public function __toString()
 	{
 		return $this->toString();
+	}
+
+	/**
+	 * Count elements of the data object
+	 *
+	 * @return  integer  The custom count as an integer.
+	 *
+	 * @link    http://php.net/manual/en/countable.count.php
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function count()
+	{
+		$i = 0;
+
+		foreach ($this->data as $item)
+		{
+			$i++;
+		}
+
+		return $i++;
 	}
 
 	/**
@@ -223,6 +243,21 @@ class Registry implements \JsonSerializable, \ArrayAccess
 		}
 
 		return self::$instances[$id];
+	}
+
+	/**
+	 * Gets this object represented as an ArrayIterator.
+	 *
+	 * This allows the data properties to be accessed via a foreach statement.
+	 *
+	 * @return  \ArrayIterator  This object represented as an ArrayIterator.
+	 *
+	 * @see     IteratorAggregate::getIterator()
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getIterator()
+	{
+		return new \ArrayIterator($this->data);
 	}
 
 	/**


### PR DESCRIPTION
This enables a `Registry` object to be counted and iterable via the `count()` function and through a `foreach` loop.
