### PR TITLE
Different separator support added

### DIFF
--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -344,6 +344,43 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Test the Joomla\Registry\Registry::loadArray method with flattened arrays
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Registry\Registry::loadArray
+	 * @since   1.0
+	 */
+	public function testLoadFlattenedArray()
+	{
+		$array = array(
+			'foo.bar'  => 1,
+			'foo.test' => 2,
+			'bar'      => 3
+		);
+		$registry = new Registry;
+		$registry->loadArray($array, true);
+
+		$this->assertThat(
+			$registry->get('foo.bar'),
+			$this->equalTo(1),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$this->assertThat(
+			$registry->get('foo.test'),
+			$this->equalTo(2),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$this->assertThat(
+			$registry->get('bar'),
+			$this->equalTo(3),
+			'Line: ' . __LINE__ . '.'
+		);
+	}
+
+	/**
 	 * Test the Joomla\Registry\Registry::loadFile method.
 	 *
 	 * @return  void
@@ -726,10 +763,17 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 	{
 		$a = new Registry;
 		$a->set('foo', 'testsetvalue1');
+		$a->set('bar/foo', 'testsetvalue3', '/');
 
 		$this->assertThat(
 			$a->set('foo', 'testsetvalue2'),
 			$this->equalTo('testsetvalue2'),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$this->assertThat(
+			$a->set('bar/foo', 'testsetvalue4'),
+			$this->equalTo('testsetvalue4'),
 			'Line: ' . __LINE__ . '.'
 		);
 	}
@@ -843,5 +887,24 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 		$flatted = $a->flatten('/');
 
 		$this->assertEquals($flatted['flower/sakura'], 'samurai');
+	}
+
+	/**
+	 * Test separator operations
+	 *
+	 * @return  void
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function testSeparator()
+	{
+		$a = new Registry;
+		$a->separator = '\\';
+		$a->set('Foo\\Bar', 'test1');
+		$a->separator = '/';
+		$a->set('Foo/Baz', 'test2');
+
+		$this->assertEquals($a->get('Foo/Bar'), 'test1');
+		$this->assertEquals($a->get('Foo/Baz'), 'test2');
 	}
 }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -34,6 +34,14 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	protected static $instances = array();
 
 	/**
+	 * Path separator
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $separator = '.';
+
+	/**
 	 * Constructor
 	 *
 	 * @param   mixed  $data  The data to bind to the new Registry object.
@@ -144,7 +152,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	public function exists($path)
 	{
 		// Explode the registry path into an array
-		$nodes = explode('.', $path);
+		$nodes = explode($this->separator, $path);
 
 		if ($nodes)
 		{
@@ -187,13 +195,13 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	{
 		$result = $default;
 
-		if (!strpos($path, '.'))
+		if (!strpos($path, $this->separator))
 		{
 			return (isset($this->data->$path) && $this->data->$path !== null && $this->data->$path !== '') ? $this->data->$path : $default;
 		}
 
 		// Explode the registry path into an array
-		$nodes = explode('.', $path);
+		$nodes = explode($this->separator, $path);
 
 		// Initialize the current node to be the registry root.
 		$node = $this->data;
@@ -263,15 +271,27 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Load a associative array of values into the default namespace
 	 *
-	 * @param   array  $array  Associative array of value to load
-	 *
+	 * @param   array    $array      Associative array of value to load
+	 * @param   boolean  $flattened  Load from a one-dimensional array
+	 * @param   string   $separator  The key separator
+	 *   
 	 * @return  Registry  Return this object to support chaining.
 	 *
 	 * @since   1.0
 	 */
-	public function loadArray($array)
+	public function loadArray($array, $flattened = false, $separator = null)
 	{
-		$this->bindData($this->data, $array);
+		if (!$flattened)
+		{
+			$this->bindData($this->data, $array);
+		}
+		else
+		{
+			foreach ($array as $k => $v)
+			{
+				$this->set($k, $v, $separator);
+			}
+		}
 
 		return $this;
 	}
@@ -357,7 +377,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Method to extract a sub-registry from path
 	 *
-	 * @param   string  $path     Registry path (e.g. joomla.content.showauthor)
+	 * @param   string  $path  Registry path (e.g. joomla.content.showauthor)
 	 *
 	 * @return  Registry|null  Registry object if data is present
 	 *
@@ -435,23 +455,29 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Set a registry value.
 	 *
-	 * @param   string  $path   Registry Path (e.g. joomla.content.showauthor)
-	 * @param   mixed   $value  Value of entry
+	 * @param   string  $path       Registry Path (e.g. joomla.content.showauthor)
+	 * @param   mixed   $value      Value of entry
+	 * @param   string  $separator  The key separator
 	 *
 	 * @return  mixed  The value of the that has been set.
 	 *
 	 * @since   1.0
 	 */
-	public function set($path, $value)
+	public function set($path, $value, $separator = null)
 	{
 		$result = null;
 
+		if (empty($separator))
+		{
+			$separator = $this->separator;
+		}
+
 		/**
 		 * Explode the registry path into an array and remove empty
-		 * nodes that occur as a result of a double dot. ex: joomla..test
+		 * nodes that occur as a result of a double separator. ex: joomla..test
 		 * Finally, re-key the array so they are sequential.
 		 */
-		$nodes = array_values(array_filter(explode('.', $path), 'strlen'));
+		$nodes = array_values(array_filter(explode($separator, $path), 'strlen'));
 
 		if ($nodes)
 		{
@@ -607,9 +633,14 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.3.0
 	 */
-	public function flatten($separator = '.')
+	public function flatten($separator = null)
 	{
 		$array = array();
+
+		if (empty($separator))
+		{
+			$separator = $this->separator;
+		}
 
 		$this->toFlatten($separator, $this->data, $array);
 
@@ -628,9 +659,14 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.3.0
 	 */
-	protected function toFlatten($separator = '.', $data = null, &$array = array(), $prefix = '')
+	protected function toFlatten($separator = null, $data = null, &$array = array(), $prefix = '')
 	{
 		$data = (array) $data;
+
+		if (empty($separator))
+		{
+			$separator = $this->separator;
+		}
 
 		foreach ($data as $k => $v)
 		{


### PR DESCRIPTION
Separator can be changed now to emulate windows-like (or any other) registry behavior.

```
$a = new Registry;
$a->separator = '\\';
$a->set('Foo\\Bar', 'mykey');
```

It also can be used when dots should be supported in keys;

```
$filehistory = new Registry;
$filehistory->separator = '/';
$filehistory->set('myfile.json', '2014-10-10');
$filehistory->set('mydir/myfile.xml', '2014-10-09');
```

Also added support to load arrays made by flatten() method. Now the registry can be safely stored in database and then loaded from it.
