### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/src/Format/Ini.php
+++ b/src/Format/Ini.php
@@ -91,12 +91,12 @@ class Ini extends AbstractRegistryFormat
 						foreach ($v as $array_key => $item)
 						{
 							$array_key = ($assoc) ? $array_key : '';
-							$local[] = $k . '[' . $array_key . ']=' . $this->getValueAsINI($item);
+							$local[] = $k . '[' . $array_key . ']=' . $this->getValueAsIni($item);
 						}
 					}
 					else
 					{
-						$local[] = $k . '=' . $this->getValueAsINI($v);
+						$local[] = $k . '=' . $this->getValueAsIni($v);
 					}
 				}
 
@@ -113,13 +113,13 @@ class Ini extends AbstractRegistryFormat
 				foreach ($value as $array_key => $item)
 				{
 					$array_key = ($assoc) ? $array_key : '';
-					$global[] = $key . '[' . $array_key . ']=' . $this->getValueAsINI($item);
+					$global[] = $key . '[' . $array_key . ']=' . $this->getValueAsIni($item);
 				}
 			}
 			else
 			{
 				// Not in a section so add the property to the global array.
-				$global[] = $key . '=' . $this->getValueAsINI($value);
+				$global[] = $key . '=' . $this->getValueAsIni($value);
 				$in_section = false;
 			}
 		}
@@ -338,7 +338,7 @@ class Ini extends AbstractRegistryFormat
 	 *
 	 * @since   1.0
 	 */
-	protected function getValueAsINI($value)
+	protected function getValueAsIni($value)
 	{
 		$string = '';
 


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.