### PR TITLE
Introduce a Factory and FormatInterface, deprecating object caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,13 @@ $registry = new Registry(array(
 $registry->loadString('<data><value name="foo" type="string">bar</value></data>, 'xml');
 ```
 
+## Custom Formats
+To load your own custom format you must implement the `Joomla\Registry\FormatInterface`. This can then be loaded through the `Joomla\Registry\Factory` class. To load a custom format not provided by Joomla then you can load it by using
+
+`Factory::getFormat($type, $options)`
+
+In this scenario `$type` contains the format (and class) name. Whilst `$options` is an array with the key `format_namespace` which contains the namespace that the format is in. 
+
 ## Installation via Composer
 
 Add `"joomla/registry": "~1.0"` to the require block in your composer.json and then run `composer install`.

--- a/Tests/FactoryTest.php
+++ b/Tests/FactoryTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Registry\Tests;
+
+use Joomla\Registry\Factory;
+use Joomla\Test\TestHelper;
+
+/**
+ * Test class for Joomla\Registry\Factory
+ */
+class FactoryTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function tearDown()
+	{
+		// Reset the internal cache
+		TestHelper::setValue('Joomla\\Registry\\Factory', 'formatInstances', array());
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox  A format object is returned from the local Joomla namespace
+	 *
+	 * @covers   Joomla\Registry\Factory::getFormat
+	 */
+	public function testGetFormatFromLocalNamespace()
+	{
+		$this->assertInstanceOf(
+			'Joomla\\Registry\\Format\\Ini',
+			Factory::getFormat('ini')
+		);
+	}
+
+	/**
+	 * @testdox  A format object is returned from the requested namespace
+	 *
+	 * @covers   Joomla\Registry\Factory::getFormat
+	 */
+	public function testGetFormatFromRequestedNamespace()
+	{
+		$this->assertInstanceOf(
+			'Joomla\\Registry\\Tests\\Stubs\\Ini',
+			Factory::getFormat('ini', array('format_namespace' => __NAMESPACE__ . '\\Stubs'))
+		);
+	}
+
+	/**
+	 * @testdox  A format object is returned from the local namespace when not found in the requested namespace
+	 *
+	 * @covers   Joomla\Registry\Factory::getFormat
+	 */
+	public function testGetFormatFromLocalNamespaceWhenRequestedNamespaceDoesNotExist()
+	{
+		$this->assertInstanceOf(
+			'Joomla\\Registry\\Format\\Json',
+			Factory::getFormat('json', array('format_namespace' => __NAMESPACE__ . '\\Stubs'))
+		);
+	}
+
+	/**
+	 * @testdox  An exception is thrown if the requested format does not exist
+	 *
+	 * @covers             Joomla\Registry\Factory::getFormat
+	 * @expectedException  \InvalidArgumentException
+	 */
+	public function testGetInstanceNonExistent()
+	{
+		Factory::getFormat('sql');
+	}
+}

--- a/Tests/Stubs/Ini.php
+++ b/Tests/Stubs/Ini.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Registry\Tests\Stubs;
+
+use Joomla\Registry\Format\Ini as BaseIni;
+
+/**
+ * Test stub for an INI format
+ */
+class Ini extends BaseIni
+{
+}

--- a/src/AbstractRegistryFormat.php
+++ b/src/AbstractRegistryFormat.php
@@ -12,8 +12,9 @@ namespace Joomla\Registry;
  * Abstract Format for Registry
  *
  * @since  1.0
+ * @deprecated  2.0  Format objects should directly implement the FormatInterface
  */
-abstract class AbstractRegistryFormat
+abstract class AbstractRegistryFormat implements FormatInterface
 {
 	/**
 	 * @var    array  Format instances container.
@@ -39,28 +40,4 @@ abstract class AbstractRegistryFormat
 	{
 		return Factory::getFormat($type);
 	}
-
-	/**
-	 * Converts an object into a formatted string.
-	 *
-	 * @param   object  $object   Data Source Object.
-	 * @param   array   $options  An array of options for the formatter.
-	 *
-	 * @return  string  Formatted string.
-	 *
-	 * @since   1.0
-	 */
-	abstract public function objectToString($object, $options = null);
-
-	/**
-	 * Converts a formatted string into an object.
-	 *
-	 * @param   string  $data     Formatted string
-	 * @param   array   $options  An array of options for the formatter.
-	 *
-	 * @return  object  Data Object
-	 *
-	 * @since   1.0
-	 */
-	abstract public function stringToObject($data, array $options = array());
 }

--- a/src/AbstractRegistryFormat.php
+++ b/src/AbstractRegistryFormat.php
@@ -17,7 +17,7 @@ namespace Joomla\Registry;
 abstract class AbstractRegistryFormat implements FormatInterface
 {
 	/**
-	 * @var    array  Format instances container.
+	 * @var    AbstractRegistryFormat[]  Format instances container.
 	 * @since  1.0
 	 * @deprecated  2.0  Object caching will no longer be supported
 	 */

--- a/src/AbstractRegistryFormat.php
+++ b/src/AbstractRegistryFormat.php
@@ -11,7 +11,7 @@ namespace Joomla\Registry;
 /**
  * Abstract Format for Registry
  *
- * @since  1.0
+ * @since       1.0
  * @deprecated  2.0  Format objects should directly implement the FormatInterface
  */
 abstract class AbstractRegistryFormat implements FormatInterface

--- a/src/AbstractRegistryFormat.php
+++ b/src/AbstractRegistryFormat.php
@@ -38,6 +38,6 @@ abstract class AbstractRegistryFormat implements FormatInterface
 	 */
 	public static function getInstance($type, array $options = array())
 	{
-		return Factory::getFormat($type);
+		return Factory::getFormat($type, $options);
 	}
 }

--- a/src/AbstractRegistryFormat.php
+++ b/src/AbstractRegistryFormat.php
@@ -18,6 +18,7 @@ abstract class AbstractRegistryFormat
 	/**
 	 * @var    array  Format instances container.
 	 * @since  1.0
+	 * @deprecated  2.0  Object caching will no longer be supported
 	 */
 	protected static $instances = array();
 
@@ -25,32 +26,18 @@ abstract class AbstractRegistryFormat
 	 * Returns a reference to a Format object, only creating it
 	 * if it doesn't already exist.
 	 *
-	 * @param   string  $type  The format to load
+	 * @param   string  $type     The format to load
+	 * @param   array   $options  Additional options to configure the object
 	 *
 	 * @return  AbstractRegistryFormat  Registry format handler
 	 *
+	 * @deprecated  2.0  Use Factory::getFormat() instead
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public static function getInstance($type)
+	public static function getInstance($type, array $options = array())
 	{
-		// Sanitize format type.
-		$type = strtolower(preg_replace('/[^A-Z0-9_]/i', '', $type));
-
-		// Only instantiate the object if it doesn't already exist.
-		if (!isset(self::$instances[$type]))
-		{
-			$class = '\\Joomla\\Registry\\Format\\' . ucfirst($type);
-
-			if (!class_exists($class))
-			{
-				throw new \InvalidArgumentException('Unable to load format class.', 500);
-			}
-
-			self::$instances[$type] = new $class;
-		}
-
-		return self::$instances[$type];
+		return Factory::getFormat($type);
 	}
 
 	/**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -18,7 +18,7 @@ class Factory
 	/**
 	 * Format instances container - for backward compatibility with AbstractRegistryFormat::getInstance().
 	 *
-	 * @var    array
+	 * @var    FormatInterface[]
 	 * @since  __DEPLOY_VERSION__
 	 * @deprecated  2.0  Object caching will no longer be supported
 	 */
@@ -30,7 +30,7 @@ class Factory
 	 * @param   string  $type     The format to load
 	 * @param   array   $options  Additional options to configure the object
 	 *
-	 * @return  AbstractRegistryFormat  Registry format handler
+	 * @return  FormatInterface  Registry format handler
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \InvalidArgumentException

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Part of the Joomla Framework Registry Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Registry;
+
+/**
+ * Factory class to fetch Registry objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Factory
+{
+	/**
+	 * Format instances container - for backward compatibility with AbstractRegistryFormat::getInstance().
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 * @deprecated  2.0  Object caching will no longer be supported
+	 */
+	protected static $formatInstances = array();
+
+	/**
+	 * Returns a AbstractRegistryFormat object, only creating it if it doesn't already exist.
+	 *
+	 * @param   string  $type     The format to load
+	 * @param   array   $options  Additional options to configure the object
+	 *
+	 * @return  AbstractRegistryFormat  Registry format handler
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
+	 */
+	public static function getFormat($type, array $options = array())
+	{
+		// Sanitize format type.
+		$type = strtolower(preg_replace('/[^A-Z0-9_]/i', '', $type));
+
+		/*
+		 * Only instantiate the object if it doesn't already exist.
+		 * @deprecated 2.0 Object caching will no longer be supported, a new instance will be returned every time
+		 */
+		if (!isset(self::$formatInstances[$type]))
+		{
+			$localNamespace = __NAMESPACE__ . '\\Format';
+			$namespace      = isset($options['format_namespace']) ? $options['format_namespace'] : $localNamespace;
+			$class          = $namespace . '\\' . ucfirst($type);
+
+			if (!class_exists($class))
+			{
+				// Were we given a custom namespace?  If not, there's nothing else we can do
+				if ($namespace === $localNamespace)
+				{
+					throw new \InvalidArgumentException(sprintf('Unable to load format class for type "%s".', $type), 500);
+				}
+
+				$class = $localNamespace . '\\' . ucfirst($type);
+
+				if (!class_exists($class))
+				{
+					throw new \InvalidArgumentException(sprintf('Unable to load format class for type "%s".', $type), 500);
+				}
+			}
+
+			self::$formatInstances[$type] = new $class;
+		}
+
+		return self::$formatInstances[$type];
+	}
+}

--- a/src/FormatInterface.php
+++ b/src/FormatInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Part of the Joomla Framework Registry Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Registry;
+
+/**
+ * Interface defining a format object
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface FormatInterface
+{
+	/**
+	 * Converts an object into a formatted string.
+	 *
+	 * @param   object  $object   Data Source Object.
+	 * @param   array   $options  An array of options for the formatter.
+	 *
+	 * @return  string  Formatted string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function objectToString($object, $options = null);
+
+	/**
+	 * Converts a formatted string into an object.
+	 *
+	 * @param   string  $data     Formatted string
+	 * @param   array   $options  An array of options for the formatter.
+	 *
+	 * @return  object  Data Object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function stringToObject($data, array $options = array());
+}

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -354,7 +354,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	public function loadString($data, $format = 'JSON', $options = array())
 	{
 		// Load a string into the given namespace [or default namespace if not given]
-		$handler = AbstractRegistryFormat::getInstance($format);
+		$handler = AbstractRegistryFormat::getInstance($format, $options);
 
 		$obj = $handler->stringToObject($data, $options);
 		$this->loadObject($obj);
@@ -644,7 +644,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	public function toString($format = 'JSON', $options = array())
 	{
 		// Return a namespace in a given format
-		$handler = AbstractRegistryFormat::getInstance($format);
+		$handler = AbstractRegistryFormat::getInstance($format, $options);
 
 		return $handler->objectToString($this->data, $options);
 	}


### PR DESCRIPTION
This PR adds a new `Factory` object which will take on responsibility for the current `getInstance()` methods in the package.  It is first implemented using the format class objects as a demonstration of the new logic.

### Factory
The `Factory::getFormat()` method continues to return the requested format object but introduces support for a custom namespace via a new options parameter.  This enables developers to extend the core formats or implement custom formats using their own namespaces.

Object caching in the format class chain is deprecated; the Factory will return a new instance of an object each time it is called in 2.0.  For backward compatibility, the Factory implements this caching for the 1.x branch.

### FormatInterface
With the `getInstance()` method deprecated, there is no compelling reason to keep using an abstract base class for format objects.  So the two abstract methods are moved to a new `FormatInterface` with the abstract class implementing this interface.  In 2.0, format objects should implement this interface directly.