### PR TITLE
Deprecate Registry::getInstance()

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -30,6 +30,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @var    array
 	 * @since  1.0
+	 * @deprecated  2.0  Object caching will no longer be supported
 	 */
 	protected static $instances = array();
 
@@ -251,6 +252,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  Registry  The Registry object.
 	 *
+	 * @deprecated  2.0  Instantiate a new Registry instance instead
 	 * @since   1.0
 	 */
 	public static function getInstance($id)


### PR DESCRIPTION
This PR deprecates the object cache in Registry and the `getInstance()` method.  The preferred way is to just instantiate a new instance and from what I can tell `getInstance()` is pretty much abandoned now anyway.

For those needing the feature, subclassing is still possible.