### PR TITLE
Fix doc block ordering

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -252,8 +252,8 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  Registry  The Registry object.
 	 *
-	 * @deprecated  2.0  Instantiate a new Registry instance instead
 	 * @since   1.0
+	 * @deprecated  2.0  Instantiate a new Registry instance instead
 	 */
 	public static function getInstance($id)
 	{


### PR DESCRIPTION
This fixes the doc block ordering to have the `@deprecated` tag under the `@since`.