### PR TITLE
Speed up loading menu params

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -26,6 +26,14 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	protected $data;
 
 	/**
+        * $data is an empty, newly created object
+        * 
+        * @var    bool
+        * @since  1.4.4
+        */
+	protected $_data_empty;
+
+       /**
 	 * Registry instances container.
 	 *
 	 * @var    array
@@ -53,11 +61,13 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	{
 		// Instantiate the internal data object.
 		$this->data = new \stdClass;
+		$this->_data_empty = true;
 
 		// Optionally load supplied data.
 		if (is_array($data) || is_object($data))
 		{
-			$this->bindData($this->data, $data);
+                        $this->_data_empty = false;
+		        $this->bindData($this->data, $data);
 
 			return;
 		}
@@ -65,6 +75,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		if (!empty($data) && is_string($data))
 		{
 			$this->loadString($data);
+			$this->_data_empty = false;
 		}
 	}
 
@@ -359,6 +370,12 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		$handler = AbstractRegistryFormat::getInstance($format, $options);
 
 		$obj = $handler->stringToObject($data, $options);
+		if($this->_data_empty)
+		{
+		       $this->data = $obj;
+		       $this->_data_empty = false;
+		       return $this;
+		}
 		$this->loadObject($obj);
 
 		return $this;
@@ -665,6 +682,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 */
 	protected function bindData($parent, $data, $recursive = true, $allowNull = true)
 	{
+               $this->_data_empty = false;
 		// Ensure the input data is an array.
 		$data = is_object($data)
 			? get_object_vars($data)


### PR DESCRIPTION


I'm working on improving performance of a Joomla site. I noticed that the longest part of generating a page is JApplicationCms->getMenu(). The query returns 380 menu items, each of them with a larger than usually params column (some extension). JApplicationCms took 1.78s to execute, out of which 1.37s has been spent in 489 calls of Registry::bindData.

Essentially, for menu items, the flow is as following:

    JMenu loads data rows, params is a JSON string
    JRegistry loadString() converts this string to an object
    JRegistry bindData() converts that object to an array
    JRegistry bindData() creates a new object, iterates over the array and copies keys as object properties
    The newly created object is returned

I propose that for simple cases like loading a menu item, the flow looks like this:

    JMenu loads data rows, params is a JSON string
    JRegistry loadString() converts this string to an object
    The object is returned

After my changes, said site takes 0.21s to execute JApplicationCms->getMenu().
