### PR TITLE
JRegistry UTF8 crash

### DIFF
--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -37,10 +37,10 @@ class Json extends AbstractRegistryFormat
 		{
 			$depth = isset($options['depth']) ? $options['depth'] : 512;
 
-			return StringHelper::unicode_to_utf8(json_encode($object, $bitmask, $depth));
+			return json_encode($object, $bitmask, $depth);
 		}
 
-		return StringHelper::unicode_to_utf8(json_encode($object, $bitmask));
+		return json_encode($object, $bitmask);
 	}
 
 	/**


### PR DESCRIPTION
An attempt to further manipulate the encoded json returned by the PHP function json_encode(), leads to a corrupted json notation.
During the opposite process, trying to recreate the Object from the corrupted data, json_decode() fails and returns an object that is not valid.

The test below uses menu item or module parameters, but note that this problem actually affects all the JRegistry objects.


#### Testing Instructions
1. Ensure to have Multibyte String PHP Extension (mb_string). This bug only affects systems with mb_strings features.
2. Create a new menu item, no matter its type. I chose "Featured Articles".
3. Fill out menu item parameters at will, for example "Page Heading" and "Show Page Heading".
4. Click Save, to ensure that the data is being saved. Not essential to reproduce the problem, but useful to see the effect of the crash.

![parameters](https://cloud.githubusercontent.com/assets/1609992/14548020/1ed5864a-02ab-11e6-9723-dd085a5ffa07.png)

5. Fill out any text field with a string that could be interpreted as an unicode character. For example, put *\u20ac* that represents the Euro sign €. British people can put *\u00a3* (Pound sign £), if they prefer. :smile: 

![unicode](https://cloud.githubusercontent.com/assets/1609992/14548031/35daa582-02ab-11e6-8c68-97d292ce0dba.png)

6. Save again.
7. All the parameters in the menu item have been wiped out.

![flushed](https://cloud.githubusercontent.com/assets/1609992/14548038/3eb09a90-02ab-11e6-9dca-31740ca7f84e.png)


#### Discussion
1. The methods unicode_to_utf8() and unicode_to_utf16() are clearly bugged
2. Even if they worked well, they would replace the string \u00a3 with £, but this replacement should not be applied at all. If the user entered \u00a3 in a text input, he expects to find the same string after save. What about entering *"\u00a3 represents £ sign"* as Browser Page Title? It would not be possible with the automatic replacement.
3. Inconsistent behaviour: Even if they worked well, they would be applied to the Parameters only. The Menu Item Title currently accepts strings like \u00a3 without applying this kind of replacement.
4. Currently they are useless, and unused. For that reasons, in my opinion they should be removed.