### PR TITLE
Fix error if load empty string first

### DIFF
--- a/Tests/format/PhpTest.php
+++ b/Tests/format/PhpTest.php
@@ -135,7 +135,7 @@ class PhpTest extends \PHPUnit_Framework_TestCase
 		$class = new Php;
 
 		// This method is not implemented in the class. The test is to achieve 100% code coverage
-		$this->assertTrue($class->stringToObject(''));
+		$this->assertInstanceOf('stdClass', $class->stringToObject(''));
 	}
 
 	/**

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -72,6 +72,6 @@ class Json extends AbstractRegistryFormat
 			throw new \RuntimeException(sprintf('Error decoding JSON data: %s', json_last_error_msg()));
 		}
 
-		return $decoded;
+		return (object) $decoded;
 	}
 }

--- a/src/Format/Php.php
+++ b/src/Format/Php.php
@@ -81,7 +81,7 @@ class Php extends AbstractRegistryFormat
 	 */
 	public function stringToObject($data, array $options = array())
 	{
-		return true;
+		return new \stdClass;
 	}
 
 	/**

--- a/src/Format/Yaml.php
+++ b/src/Format/Yaml.php
@@ -79,6 +79,6 @@ class Yaml extends AbstractRegistryFormat
 	{
 		$array = $this->parser->parse(trim($data));
 
-		return json_decode(json_encode($array));
+		return (object) json_decode(json_encode($array));
 	}
 }


### PR DESCRIPTION
### Summary of Changes

This PR fixed a simple bug after we load empty string first then load other data. (which is also exists in Joomla 3.6.*)

For example, this code will raise an error: `Creating default object from empty value`

``` php
$r = new Registry;

$r->loadString('', 'yaml')
	->loadFile(__DIR__ . '/Stubs/jregistry.json');
```

Because the initial data will directly store to `$this->data`, so we must make sure all Format class return object not array or string.

See https://github.com/joomla-framework/registry/blob/e65fe441433dd9c3d293aef34ab79e85e10a806e/src/Registry.php#L371

### Testing Instructions

Load empty first and load a new data, Registry will raise an error.
