### PR TITLE
Allow a Registry to be instantiated with another Registry

### DIFF
--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -52,6 +52,19 @@ class RegistryTest extends TestCase
 	}
 
 	/**
+	 * @testdox  A Registry instance is instantiated with another Registry
+	 *
+	 * @covers   Joomla\Registry\Registry::__construct
+	 */
+	public function testARegistryInstanceIsInstantiatedWithAnotherRegistry()
+	{
+		$a = new Registry(array('foo' => 'bar'));
+		$b = new Registry($a);
+
+		$this->assertSame(1, count($b), 'The Registry data store should not be empty.');
+	}
+
+	/**
 	 * @testdox  A Registry instance instantiated with a string of data is correctly manipulated
 	 *
 	 * @covers   Joomla\Registry\Registry::__construct

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -20,7 +20,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Registry Object
 	 *
-	 * @var    object
+	 * @var    \stdClass
 	 * @since  1.0
 	 */
 	protected $data;
@@ -36,7 +36,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Registry instances container.
 	 *
-	 * @var    array
+	 * @var    Registry[]
 	 * @since  1.0
 	 * @deprecated  1.5.0  Object caching will no longer be supported
 	 */
@@ -63,7 +63,11 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		$this->data = new \stdClass;
 
 		// Optionally load supplied data.
-		if (is_array($data) || is_object($data))
+		if ($data instanceof Registry)
+		{
+			$this->merge($data);
+		}
+		elseif (is_array($data) || is_object($data))
 		{
 			$this->bindData($this->data, $data);
 		}


### PR DESCRIPTION
Some issues have cropped up in the CMS where some code tries to create a new `Registry` instance using another `Registry` as the parameter, but it's not really handled well through the constructor right now.  Let's fix this.

If the constructor receives a `Registry` as its data object, `$registry->merge()` will be called to merge the injected object into the new object.