### PR TITLE
Cleanup and Performance

### DIFF
--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -24,7 +24,7 @@ class RegistryTest extends TestCase
 	{
 		$a = new Registry;
 
-		$this->assertSame(0, count($a), 'The Registry data store should be empty.');
+		$this->assertCount(0, $a, 'The Registry data store should be empty.');
 	}
 
 	/**
@@ -36,7 +36,7 @@ class RegistryTest extends TestCase
 	{
 		$a = new Registry(array('foo' => 'bar'));
 
-		$this->assertSame(1, count($a), 'The Registry data store should not be empty.');
+		$this->assertCount(1, $a, 'The Registry data store should not be empty.');
 	}
 
 	/**
@@ -48,7 +48,7 @@ class RegistryTest extends TestCase
 	{
 		$a = new Registry(json_encode(array('foo' => 'bar')));
 
-		$this->assertSame(1, count($a), 'The Registry data store should not be empty.');
+		$this->assertCount(1, $a, 'The Registry data store should not be empty.');
 	}
 
 	/**
@@ -61,7 +61,7 @@ class RegistryTest extends TestCase
 		$a = new Registry(array('foo' => 'bar'));
 		$b = new Registry($a);
 
-		$this->assertSame(1, count($b), 'The Registry data store should not be empty.');
+		$this->assertCount(1, $b, 'The Registry data store should not be empty.');
 	}
 
 	/**
@@ -137,7 +137,7 @@ class RegistryTest extends TestCase
 			)
 		);
 
-		$this->assertSame(3, count($a), 'count() should correctly count the number of data elements.');
+		$this->assertCount(3, $a, 'count() should correctly count the number of data elements.');
 	}
 
 	/**
@@ -522,7 +522,7 @@ class RegistryTest extends TestCase
 	{
 		$instance = new Registry;
 
-		$this->assertTrue(empty($instance['foo.bar']), 'Checks an offset is empty.');
+		$this->assertEmpty($instance['foo.bar'], 'Checks an offset is empty.');
 
 		$instance->set('foo.bar', 'value');
 

--- a/Tests/Stubs/jregistry.php
+++ b/Tests/Stubs/jregistry.php
@@ -3,5 +3,5 @@ namespace Joomla\Registry\Tests\Stubs;
 
 class JRegistry {
 	public $foo = 'bar';
-	public $nested = array("foo" => "bar");
+	public $nested = array('foo' => 'bar');
 }

--- a/Tests/format/XmlTest.php
+++ b/Tests/format/XmlTest.php
@@ -36,26 +36,24 @@ class XmlTest extends TestCase
 		$object->array = array('nestedarray' => array('test1' => 'value1'));
 
 		// Check for different PHP behavior of displaying boolean false in XML.
-		$checkFalse = '<check/>' == simplexml_load_string('<test/>')->addChild('check', false)->asXML()
-			? '/>'
-			: '></node>';
+		$checkFalse = '<check/>' === simplexml_load_string('<test/>')->addChild('check', false)->asXML() ? '/>' : '></node>';
 
 		$string = "<?xml version=\"1.0\"?>\n<registry>" .
-			"<node name=\"foo\" type=\"string\">bar</node>" .
-			"<node name=\"quoted\" type=\"string\">\"stringwithquotes\"</node>" .
-			"<node name=\"booleantrue\" type=\"boolean\">1</node>" .
-			"<node name=\"booleanfalse\" type=\"boolean\"" . $checkFalse .
-			"<node name=\"numericint\" type=\"integer\">42</node>" .
-			"<node name=\"numericfloat\" type=\"double\">3.1415</node>" .
-			"<node name=\"section\" type=\"object\">" .
-			"<node name=\"key\" type=\"string\">value</node>" .
-			"</node>" .
-			"<node name=\"array\" type=\"array\">" .
-			"<node name=\"nestedarray\" type=\"array\">" .
-			"<node name=\"test1\" type=\"string\">value1</node>" .
-			"</node>" .
-			"</node>" .
-			"</registry>\n";
+			'<node name="foo" type="string">bar</node>' .
+			'<node name="quoted" type="string">"stringwithquotes"</node>' .
+			'<node name="booleantrue" type="boolean">1</node>' .
+			'<node name="booleanfalse" type="boolean"' . $checkFalse .
+			'<node name="numericint" type="integer">42</node>' .
+			'<node name="numericfloat" type="double">3.1415</node>' .
+			'<node name="section" type="object">' .
+			'<node name="key" type="string">value</node>' .
+			'</node>' .
+			'<node name="array" type="array">' .
+			'<node name="nestedarray" type="array">' .
+			'<node name="test1" type="string">value1</node>' .
+			'</node>' .
+			'</node>' .
+			'</registry>' . "\n";
 
 		// Test basic object to string.
 		$this->assertSame($string, $class->objectToString($object));
@@ -83,19 +81,19 @@ class XmlTest extends TestCase
 		$object->array = array('test1' => 'value1');
 
 		$string = "<?xml version=\"1.0\"?>\n<registry>" .
-			"<node name=\"foo\" type=\"string\">bar</node>" .
-			"<node name=\"booleantrue\" type=\"boolean\">1</node>" .
-			"<node name=\"booleanfalse1\" type=\"boolean\"></node>" .
-			"<node name=\"booleanfalse2\" type=\"boolean\"/>" .
-			"<node name=\"numericint\" type=\"integer\">42</node>" .
-			"<node name=\"numericfloat\" type=\"double\">3.1415</node>" .
-			"<node name=\"section\" type=\"object\">" .
-			"<node name=\"key\" type=\"string\">value</node>" .
-			"</node>" .
-			"<node name=\"array\" type=\"array\">" .
-			"<node name=\"test1\" type=\"string\">value1</node>" .
-			"</node>" .
-			"</registry>\n";
+			'<node name="foo" type="string">bar</node>' .
+			'<node name="booleantrue" type="boolean">1</node>' .
+			'<node name="booleanfalse1" type="boolean"></node>' .
+			'<node name="booleanfalse2" type="boolean"/>' .
+			'<node name="numericint" type="integer">42</node>' .
+			'<node name="numericfloat" type="double">3.1415</node>' .
+			'<node name="section" type="object">' .
+			'<node name="key" type="string">value</node>' .
+			'</node>' .
+			'<node name="array" type="array">' .
+			'<node name="test1" type="string">value1</node>' .
+			'</node>' .
+			'</registry>' . "\n";
 
 		// Test basic object to string.
 		$this->assertEquals($object, $class->stringToObject($string));
@@ -112,23 +110,21 @@ class XmlTest extends TestCase
 		$class = new Xml;
 
 		// Check for different PHP behavior of displaying boolean false in XML.
-		$checkFalse = '<check/>' == simplexml_load_string('<test/>')->addChild('check', false)->asXML()
-			? '/>'
-			: '></node>';
+		$checkFalse = '<check/>' === simplexml_load_string('<test/>')->addChild('check', false)->asXML() ? '/>' : '></node>';
 
 		$input = "<?xml version=\"1.0\"?>\n<registry>" .
-			"<node name=\"foo\" type=\"string\">bar</node>" .
-			"<node name=\"booleantrue\" type=\"boolean\">1</node>" .
-			"<node name=\"booleanfalse\" type=\"boolean\"" . $checkFalse .
-			"<node name=\"numericint\" type=\"integer\">42</node>" .
-			"<node name=\"numericfloat\" type=\"double\">3.1415</node>" .
-			"<node name=\"section\" type=\"object\">" .
-			"<node name=\"key\" type=\"string\">value</node>" .
-			"</node>" .
-			"<node name=\"array\" type=\"array\">" .
-			"<node name=\"test1\" type=\"string\">value1</node>" .
-			"</node>" .
-			"</registry>\n";
+			'<node name="foo" type="string">bar</node>' .
+			'<node name="booleantrue" type="boolean">1</node>' .
+			'<node name="booleanfalse" type="boolean"' . $checkFalse .
+			'<node name="numericint" type="integer">42</node>' .
+			'<node name="numericfloat" type="double">3.1415</node>' .
+			'<node name="section" type="object">' .
+			'<node name="key" type="string">value</node>' .
+			'</node>' .
+			'<node name="array" type="array">' .
+			'<node name="test1" type="string">value1</node>' .
+			'</node>' .
+			'</registry>' . "\n";
 
 		$object = $class->stringToObject($input);
 		$output = $class->objectToString($object);

--- a/src/Format/Ini.php
+++ b/src/Format/Ini.php
@@ -32,7 +32,7 @@ class Ini extends AbstractRegistryFormat
 	);
 
 	/**
-	 * A cache used by stringToobject.
+	 * A cache used by stringToObject.
 	 *
 	 * @var    array
 	 * @since  1.0

--- a/src/Format/Ini.php
+++ b/src/Format/Ini.php
@@ -168,7 +168,7 @@ class Ini extends AbstractRegistryFormat
 			$line = trim($line);
 
 			// Ignore empty lines and comments.
-			if (empty($line) || ($line{0} === ';'))
+			if (empty($line) || ($line[0] === ';'))
 			{
 				continue;
 			}
@@ -178,14 +178,14 @@ class Ini extends AbstractRegistryFormat
 				$length = strlen($line);
 
 				// If we are processing sections and the line is a section add the object and continue.
-				if (($line[0] === '[') && ($line[$length - 1] === ']'))
+				if ($line[0] === '[' && ($line[$length - 1] === ']'))
 				{
 					$section       = substr($line, 1, $length - 2);
 					$obj->$section = new stdClass;
 					continue;
 				}
 			}
-			elseif ($line{0} === '[')
+			elseif ($line[0] === '[')
 			{
 				continue;
 			}

--- a/src/Format/Ini.php
+++ b/src/Format/Ini.php
@@ -54,9 +54,10 @@ class Ini extends AbstractRegistryFormat
 	 */
 	public function objectToString($object, $options = array())
 	{
-		$options = array_merge(self::$options, $options);
+		$options            = array_merge(self::$options, $options);
+		$supportArrayValues = $options['supportArrayValues'];
 
-		$local = array();
+		$local  = array();
 		$global = array();
 
 		$variables = get_object_vars($object);
@@ -84,14 +85,14 @@ class Ini extends AbstractRegistryFormat
 				// Add the properties for this section.
 				foreach (get_object_vars($value) as $k => $v)
 				{
-					if (is_array($v) && $options['supportArrayValues'])
+					if (is_array($v) && $supportArrayValues)
 					{
 						$assoc = ArrayHelper::isAssociative($v);
 
 						foreach ($v as $array_key => $item)
 						{
-							$array_key = ($assoc) ? $array_key : '';
-							$local[] = $k . '[' . $array_key . ']=' . $this->getValueAsIni($item);
+							$array_key = $assoc ? $array_key : '';
+							$local[]   = $k . '[' . $array_key . ']=' . $this->getValueAsIni($item);
 						}
 					}
 					else
@@ -101,25 +102,25 @@ class Ini extends AbstractRegistryFormat
 				}
 
 				// Add empty line after section if it is not the last one
-				if (0 != --$last)
+				if (0 !== --$last)
 				{
 					$local[] = '';
 				}
 			}
-			elseif (is_array($value) && $options['supportArrayValues'])
+			elseif (is_array($value) && $supportArrayValues)
 			{
 				$assoc = ArrayHelper::isAssociative($value);
 
 				foreach ($value as $array_key => $item)
 				{
-					$array_key = ($assoc) ? $array_key : '';
-					$global[] = $key . '[' . $array_key . ']=' . $this->getValueAsIni($item);
+					$array_key = $assoc ? $array_key : '';
+					$global[]  = $key . '[' . $array_key . ']=' . $this->getValueAsIni($item);
 				}
 			}
 			else
 			{
 				// Not in a section so add the property to the global array.
-				$global[] = $key . '=' . $this->getValueAsIni($value);
+				$global[]   = $key . '=' . $this->getValueAsIni($value);
 				$in_section = false;
 			}
 		}
@@ -155,10 +156,10 @@ class Ini extends AbstractRegistryFormat
 			return new stdClass;
 		}
 
-		$obj = new stdClass;
+		$obj     = new stdClass;
 		$section = false;
-		$array = false;
-		$lines = explode("\n", $data);
+		$array   = false;
+		$lines   = explode("\n", $data);
 
 		// Process the lines.
 		foreach ($lines as $line)
@@ -167,7 +168,7 @@ class Ini extends AbstractRegistryFormat
 			$line = trim($line);
 
 			// Ignore empty lines and comments.
-			if (empty($line) || ($line{0} == ';'))
+			if (empty($line) || ($line{0} === ';'))
 			{
 				continue;
 			}
@@ -177,14 +178,14 @@ class Ini extends AbstractRegistryFormat
 				$length = strlen($line);
 
 				// If we are processing sections and the line is a section add the object and continue.
-				if (($line[0] == '[') && ($line[$length - 1] == ']'))
+				if (($line[0] === '[') && ($line[$length - 1] === ']'))
 				{
-					$section = substr($line, 1, $length - 2);
+					$section       = substr($line, 1, $length - 2);
 					$obj->$section = new stdClass;
 					continue;
 				}
 			}
-			elseif ($line{0} == '[')
+			elseif ($line{0} === '[')
 			{
 				continue;
 			}
@@ -200,11 +201,11 @@ class Ini extends AbstractRegistryFormat
 			list ($key, $value) = explode('=', $line, 2);
 
 			// If we have an array item
-			if (substr($key, -1) == ']' && ($open_brace = strpos($key, '[', 1)) !== false)
+			if (substr($key, -1) === ']' && ($open_brace = strpos($key, '[', 1)) !== false)
 			{
 				if ($options['supportArrayValues'])
 				{
-					$array = true;
+					$array     = true;
 					$array_key = substr($key, $open_brace + 1, -1);
 
 					// If we have a multi-dimensional array or malformed key
@@ -232,10 +233,10 @@ class Ini extends AbstractRegistryFormat
 			// If the value is quoted then we assume it is a string.
 			$length = strlen($value);
 
-			if ($length && ($value[0] == '"') && ($value[$length - 1] == '"'))
+			if ($length && ($value[0] === '"') && ($value[$length - 1] === '"'))
 			{
 				// Strip the quotes and Convert the new line characters.
-				$value = stripcslashes(substr($value, 1, ($length - 2)));
+				$value = stripcslashes(substr($value, 1, $length - 2));
 				$value = str_replace('\n', "\n", $value);
 			}
 			else
@@ -243,22 +244,22 @@ class Ini extends AbstractRegistryFormat
 				// If the value is not quoted, we assume it is not a string.
 
 				// If the value is 'false' assume boolean false.
-				if ($value == 'false')
+				if ($value === 'false')
 				{
 					$value = false;
 				}
-				elseif ($value == 'true')
-				// If the value is 'true' assume boolean true.
+				elseif ($value === 'true')
+					// If the value is 'true' assume boolean true.
 				{
 					$value = true;
 				}
 				elseif ($options['parseBooleanWords'] && in_array(strtolower($value), array('yes', 'no')))
-				// If the value is 'yes' or 'no' and option is enabled assume appropriate boolean
+					// If the value is 'yes' or 'no' and option is enabled assume appropriate boolean
 				{
-					$value = (strtolower($value) == 'yes');
+					$value = (strtolower($value) === 'yes');
 				}
 				elseif (is_numeric($value))
-				// If the value is numeric than it is either a float or int.
+					// If the value is numeric than it is either a float or int.
 				{
 					// If there is a period then we assume a float.
 					if (strpos($value, '.') !== false)

--- a/src/Format/Ini.php
+++ b/src/Format/Ini.php
@@ -253,7 +253,7 @@ class Ini extends AbstractRegistryFormat
 				{
 					$value = true;
 				}
-				elseif ($options['parseBooleanWords'] && in_array(strtolower($value), array('yes', 'no')))
+				elseif ($options['parseBooleanWords'] && in_array(strtolower($value), array('yes', 'no'), true))
 					// If the value is 'yes' or 'no' and option is enabled assume appropriate boolean
 				{
 					$value = (strtolower($value) === 'yes');

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -20,8 +20,8 @@ class Json extends AbstractRegistryFormat
 	/**
 	 * Converts an object into a JSON formatted string.
 	 *
-	 * @param   object  $object   Data source object.
-	 * @param   array   $options  Options used by the formatter.
+	 * @param   object $object  Data source object.
+	 * @param   array  $options Options used by the formatter.
 	 *
 	 * @return  string  JSON formatted string.
 	 *
@@ -58,9 +58,9 @@ class Json extends AbstractRegistryFormat
 	public function stringToObject($data, array $options = array('processSections' => false))
 	{
 		$data = trim($data);
-		if ($data !== '' && $data[0]!== '{')
+		if ($data !== '' && $data[0] !== '{')
 		{
-				return AbstractRegistryFormat::getInstance('Ini')->stringToObject($data, $options);
+			return AbstractRegistryFormat::getInstance('Ini')->stringToObject($data, $options);
 		}
 		$decoded = json_decode($data);
 

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -58,12 +58,10 @@ class Json extends AbstractRegistryFormat
 	public function stringToObject($data, array $options = array('processSections' => false))
 	{
 		$data = trim($data);
-
-		if ((substr($data, 0, 1) != '{') && (substr($data, -1, 1) != '}'))
+		if ($data !== '' && $data[0]!== '{')
 		{
-			return AbstractRegistryFormat::getInstance('Ini')->stringToObject($data, $options);
+				return AbstractRegistryFormat::getInstance('Ini')->stringToObject($data, $options);
 		}
-
 		$decoded = json_decode($data);
 
 		// Check for an error decoding the data

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -20,8 +20,8 @@ class Json extends AbstractRegistryFormat
 	/**
 	 * Converts an object into a JSON formatted string.
 	 *
-	 * @param   object $object  Data source object.
-	 * @param   array  $options Options used by the formatter.
+	 * @param   object  $object   Data source object.
+	 * @param   array   $options  Options used by the formatter.
 	 *
 	 * @return  string  JSON formatted string.
 	 *
@@ -58,10 +58,12 @@ class Json extends AbstractRegistryFormat
 	public function stringToObject($data, array $options = array('processSections' => false))
 	{
 		$data = trim($data);
+
 		if ($data !== '' && $data[0] !== '{')
 		{
 			return AbstractRegistryFormat::getInstance('Ini')->stringToObject($data, $options);
 		}
+
 		$decoded = json_decode($data);
 
 		// Check for an error decoding the data

--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -29,17 +29,17 @@ class Json extends AbstractRegistryFormat
 	 */
 	public function objectToString($object, $options = array())
 	{
-		$bitmask = isset($options['bitmask']) ? $options['bitmask'] : 0;
+		$bitMask = isset($options['bitmask']) ? $options['bitmask'] : 0;
 
 		// The depth parameter is only present as of PHP 5.5
 		if (version_compare(PHP_VERSION, '5.5', '>='))
 		{
 			$depth = isset($options['depth']) ? $options['depth'] : 512;
 
-			return json_encode($object, $bitmask, $depth);
+			return json_encode($object, $bitMask, $depth);
 		}
 
-		return json_encode($object, $bitmask);
+		return json_encode($object, $bitMask);
 	}
 
 	/**

--- a/src/Format/Php.php
+++ b/src/Format/Php.php
@@ -89,7 +89,7 @@ class Php extends AbstractRegistryFormat
 	 *
 	 * @param   array  $a  The array to get as a string.
 	 *
-	 * @return  array
+	 * @return  string
 	 *
 	 * @since   1.0
 	 */

--- a/src/Format/Php.php
+++ b/src/Format/Php.php
@@ -44,21 +44,21 @@ class Php extends AbstractRegistryFormat
 			}
 			elseif (is_array($v) || is_object($v))
 			{
-				$vars .= "\tpublic $" . $k . " = " . $this->getArrayString((array) $v) . ";\n";
+				$vars .= "\tpublic $" . $k . ' = ' . $this->getArrayString((array) $v) . ";\n";
 			}
 		}
 
 		$str = "<?php\n";
 
 		// If supplied, add a namespace to the class object
-		if (isset($params['namespace']) && $params['namespace'] != '')
+		if (isset($params['namespace']) && $params['namespace'] !== '')
 		{
-			$str .= "namespace " . $params['namespace'] . ";\n\n";
+			$str .= 'namespace ' . $params['namespace'] . ";\n\n";
 		}
 
-		$str .= "class " . $class . " {\n";
+		$str .= 'class ' . $class . " {\n";
 		$str .= $vars;
-		$str .= "}";
+		$str .= '}';
 
 		// Use the closing tag if it not set to false in parameters.
 		if (!isset($params['closingtag']) || $params['closingtag'] !== false)
@@ -100,7 +100,7 @@ class Php extends AbstractRegistryFormat
 
 		foreach ($a as $k => $v)
 		{
-			$s .= ($i) ? ', ' : '';
+			$s .= $i ? ', ' : '';
 			$s .= '"' . $k . '" => ';
 
 			if (is_array($v) || is_object($v))

--- a/src/Format/Xml.php
+++ b/src/Format/Xml.php
@@ -33,8 +33,8 @@ class Xml extends AbstractRegistryFormat
 	 */
 	public function objectToString($object, $options = array())
 	{
-		$rootName = (isset($options['name'])) ? $options['name'] : 'registry';
-		$nodeName = (isset($options['nodeName'])) ? $options['nodeName'] : 'node';
+		$rootName = isset($options['name']) ? $options['name'] : 'registry';
+		$nodeName = isset($options['nodeName']) ? $options['nodeName'] : 'node';
 
 		// Create the root node.
 		$root = simplexml_load_string('<' . $rootName . ' />');

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -418,7 +418,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	{
 		$data = $this->get($path);
 
-		if (is_null($data))
+		if ($data === null)
 		{
 			return null;
 		}
@@ -521,7 +521,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		{
 			if (is_object($node))
 			{
-				if (!isset($node->{$nodes[$i]}) && ($i != $n))
+				if (!isset($node->{$nodes[$i]}) && ($i !== $n))
 				{
 					$node->{$nodes[$i]} = new \stdClass;
 				}
@@ -534,7 +534,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 
 			if (is_array($node))
 			{
-				if (!isset($node[$nodes[$i]]) && ($i != $n))
+				if (($i !== $n) && !isset($node[$nodes[$i]]))
 				{
 					$node[$nodes[$i]] = new \stdClass;
 				}
@@ -595,7 +595,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 			{
 				if (is_object($node))
 				{
-					if (!isset($node->{$nodes[$i]}) && ($i != $n))
+					if (!isset($node->{$nodes[$i]}) && ($i !== $n))
 					{
 						$node->{$nodes[$i]} = new \stdClass;
 					}
@@ -605,7 +605,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 				}
 				elseif (is_array($node))
 				{
-					if (!isset($node[$nodes[$i]]) && ($i != $n))
+					if (($i !== $n) && !isset($node[$nodes[$i]]))
 					{
 						$node[$nodes[$i]] = new \stdClass;
 					}
@@ -621,7 +621,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 				$node = get_object_vars($node);
 			}
 
-			array_push($node, $value);
+			$node[] = $value;
 			$result = $value;
 		}
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -80,8 +80,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Magic function to clone the registry object.
 	 *
-	 * @return  Registry
-	 *
 	 * @since   1.0
 	 */
 	public function __clone()
@@ -389,7 +387,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @param   Registry  $source     Source Registry object to merge.
 	 * @param   boolean   $recursive  True to support recursive merge the children values.
 	 *
-	 * @return  Registry  Return this object to support chaining.
+	 * @return  Registry|false  Return this object to support chaining or false if $source is not an instance of Registry.
 	 *
 	 * @since   1.0
 	 */

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -80,6 +80,8 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Magic function to clone the registry object.
 	 *
+	 * @return  void
+	 *
 	 * @since   1.0
 	 */
 	public function __clone()

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -167,7 +167,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		$nodes = explode($this->separator, $path);
 
 		// Initialize the current node to be the registry root.
-		$node = $this->data;
+		$node  = $this->data;
 		$found = false;
 
 		// Traverse the registry to find the correct node for the result.
@@ -175,7 +175,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		{
 			if (is_array($node) && isset($node[$n]))
 			{
-				$node = $node[$n];
+				$node  = $node[$n];
 				$found = true;
 				continue;
 			}
@@ -185,7 +185,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 				return false;
 			}
 
-			$node = $node->$n;
+			$node  = $node->$n;
 			$found = true;
 		}
 
@@ -219,7 +219,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		$nodes = explode($this->separator, trim($path));
 
 		// Initialize the current node to be the registry root.
-		$node = $this->data;
+		$node  = $this->data;
 		$found = false;
 
 		// Traverse the registry to find the correct node for the result.
@@ -227,7 +227,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		{
 			if (is_array($node) && isset($node[$n]))
 			{
-				$node = $node[$n];
+				$node  = $node[$n];
 				$found = true;
 
 				continue;
@@ -238,7 +238,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 				return $default;
 			}
 
-			$node = $node->$n;
+			$node  = $node->$n;
 			$found = true;
 		}
 
@@ -616,7 +616,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 			}
 
 			if (!is_array($node))
-			// Convert the node to array to make append possible
+				// Convert the node to array to make append possible
 			{
 				$node = get_object_vars($node);
 			}
@@ -688,9 +688,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		$this->initialized = true;
 
 		// Ensure the input data is an array.
-		$data = is_object($data)
-			? get_object_vars($data)
-			: (array) $data;
+		$data = is_object($data) ? get_object_vars($data) : (array) $data;
 
 		foreach ($data as $k => $v)
 		{


### PR DESCRIPTION
### Summary of Changes
- replace substr with array access
- no need to check if there is a closing curly brace. json_decode will later cause an exception if there is a problem with JSON. Also ini files (strings) do not have curly braces at start/end
- extracted an array accessed variable that was looped unnecessarily in a loop
- type safe comparisons
- removal of unnecessary parentheses
- double quotes to single quotes
- replace is_null()
- flip conditions where the latter was cheaper
- formatting

- [tests]
  - quotes to doublequotes
  - replaced assertions

### Testing Instructions
Code review?

