### PR TITLE
[2.0] Improve Json Format new registry performance a bit

### DIFF
--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -31,7 +31,7 @@ class Json implements FormatInterface
 	public function objectToString($object, array $options = [])
 	{
 		$bitMask = isset($options['bitmask']) ? $options['bitmask'] : 0;
-		$depth = isset($options['depth']) ? $options['depth'] : 512;
+		$depth   = isset($options['depth']) ? $options['depth'] : 512;
 
 		return json_encode($object, $bitMask, $depth);
 	}
@@ -51,18 +51,19 @@ class Json implements FormatInterface
 	 */
 	public function stringToObject($data, array $options = ['processSections' => false])
 	{
-		$data = trim($data);
-
-		if ($data !== '' && $data[0] !== '{')
-		{
-			return Factory::getFormat('Ini')->stringToObject($data, $options);
-		}
-
 		$decoded = json_decode($data);
 
 		// Check for an error decoding the data
 		if ($decoded === null)
 		{
+			$data = trim($data);
+
+			// If it's an ini file, parse as ini.
+			if ($data !== '' && $data[0] !== '{')
+			{
+				return Factory::getFormat('Ini')->stringToObject($data, $options);
+			}
+
 			throw new \RuntimeException(sprintf('Error decoding JSON data: %s', json_last_error_msg()));
 		}
 


### PR DESCRIPTION
### Summary of Changes

In Json format move the ini checking and parsing only if the json decode fails. 

Please note that i have some doubts this will work in all cases (especially the ones that start don't start with `{`, so please review properly and if needed should we add more test cases?

### Testing Instructions

1. Unit tests pass
2. Code review
3. To test use the following code in a cms 4.0 template index.php before and after the PR and notice the times (thsi is for 1000 registry object creations)
```php
use \Joomla\Registry\Registry;

$iterations = 1000;
$strings    = [
	'{}',
	' { "aaa" : 1 } ',
	'[]',
	'[inisection]
	A="1"
	',
	'{
	 "test" : 1,
	"test2" : "2"
	}',
	'[section]
	test1 = "aaa"
	test2 = "bbb"
	test2 = "bbb"
	',
];

foreach ($strings as $string)
{
	$start = microtime(true);
	for ($i = 1; $i <= $iterations; $i++)
	{
		new Registry($string);
	}
	echo '- [' . number_format(((microtime(true) - $start) * 1000), 3) . ' ms]' .PHP_EOL;
	//var_dump(new Registry($string));
}
```
4. Check if the registry objects are the same

My best results on PHP 7.0.19 in Linux for this urls parsed:

| Test | Before  | After |
| ------------- | ------------- | ------------- |
| Empty json object | 3.074 ms  | 2.736 ms  |
| simple json object | 3.996 ms  | 3.161 ms  |
| Empty json array | 6.326 ms  | 3.584 ms  |
| ini with section 1 | 5.838 ms  | 7.343 ms  |
| normal json | 3.857 ms  | 3.722 ms  |
| ini with section 2 | 5.775 ms  | 6.497 ms  |

Note: the ini parts are less performance now, but IMHO that is not a problem as it should be using the ini format - not json, here should be just a fallback for edge cases.

### Documentation Changes Required

None.

@frankmayer please check.