### PR TITLE
Safe mode in which extract always returns a Registry

### DIFF
--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -464,15 +464,15 @@ class RegistryTest extends TestCase
 	}
 
 	/**
-	 * @testdox  A Registry cannot be extracted from null data
+	 * @testdox  A Registry can be extracted from null data
 	 *
 	 * @covers   Joomla\Registry\Registry::extract
 	 */
-	public function testARegistryCannotBeExtractedFromNullData()
+	public function testARegistryCanBeExtractedFromNullData()
 	{
 		$a = new Registry;
 
-		$this->assertNull($a->extract('foo'), 'A Registry cannot be extracted from null data.');
+		$this->assertInstanceOf(Registry::class, $a->extract('foo'), 'A Registry can be extracted from null data.');
 	}
 
 	/**

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -30,3 +30,7 @@ argument as an array; this was not enforced in v1.
 
 Several methods in the `Registry` class are now typehinted, this affects methods with an argument requiring an array and the
 `Registry::merge()` method which now typehints the `$source` argument.
+
+### Joomla\Registry\Registry::extract() always returns a Registry
+
+Previously when there was no data for a key, `Registry::extract()` would return a null value. In 2.0, the null return is removed and an empty `Registry` is returned.

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -369,19 +369,20 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Method to extract a sub-registry from path
 	 *
-	 * @param   string  $path  Registry path (e.g. joomla.content.showauthor)
+	 * @param   string   $path  Registry path (e.g. joomla.content.showauthor)
+	 * @param   boolean  $safe  If true, will always return a Registry
 	 *
 	 * @return  Registry|null  Registry object if data is present
 	 *
 	 * @since   1.2.0
 	 */
-	public function extract($path)
+	public function extract($path, $safe = false)
 	{
 		$data = $this->get($path);
 
 		if ($data === null)
 		{
-			return null;
+			return $safe ? new Registry : null;
 		}
 
 		return new Registry($data);

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -369,21 +369,15 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Method to extract a sub-registry from path
 	 *
-	 * @param   string   $path  Registry path (e.g. joomla.content.showauthor)
-	 * @param   boolean  $safe  If true, will always return a Registry
+	 * @param   string  $path  Registry path (e.g. joomla.content.showauthor)
 	 *
-	 * @return  Registry|null  Registry object if data is present
+	 * @return  Registry  Registry object (empty if no data is present)
 	 *
 	 * @since   1.2.0
 	 */
-	public function extract($path, $safe = false)
+	public function extract($path)
 	{
 		$data = $this->get($path);
-
-		if ($data === null)
-		{
-			return $safe ? new Registry : null;
-		}
 
 		return new Registry($data);
 	}


### PR DESCRIPTION
### Summary of Changes

Always return a Registry no matter what. Because sometimes I may want to write something like:

```php
$example = $params->extract('example')->toArray();
```

but it's dangerous to do this when `extract` may return null. So now I can write:

```php
$example = $params->extract('example')->toArray();
```

and have no worries.

This presents a minor BC issue in case you were relying on the result of `extract()` to inform you whether or not any data was present at the specified path by testing it for `null`. How this could possibly have any serious impact is hard to imagine but the possibility can never be ruled out entirely. 

### Testing Instructions

I don't know. Maybe try this code I just wrote in the above section.

### Documentation Changes Required

Maybe some note about the miniscule BC issue. 