### PR TITLE
[2.0] Support null value in PHP format

### DIFF
--- a/Tests/format/PhpTest.php
+++ b/Tests/format/PhpTest.php
@@ -29,6 +29,7 @@ class PhpTest extends TestCase
 		$object->quoted = '"stringwithquotes"';
 		$object->booleantrue = true;
 		$object->booleanfalse = false;
+		$object->nullvalue = null;
 		$object->numericint = 42;
 		$object->numericfloat = 3.1415;
 		$object->section = new \stdClass;
@@ -41,6 +42,7 @@ class PhpTest extends TestCase
 			"\tpublic \$quoted = '\"stringwithquotes\"';\n" .
 			"\tpublic \$booleantrue = true;\n" .
 			"\tpublic \$booleanfalse = false;\n" .
+			"\tpublic \$nullvalue = null;\n" .
 			"\tpublic \$numericint = 42;\n" .
 			"\tpublic \$numericfloat = 3.1415;\n" .
 			"\tpublic \$section = array('key' => 'value');\n" .
@@ -63,6 +65,7 @@ class PhpTest extends TestCase
 		$object->quoted = '"stringwithquotes"';
 		$object->booleantrue = true;
 		$object->booleanfalse = false;
+		$object->nullvalue = null;
 		$object->numericint = 42;
 		$object->numericfloat = 3.1415;
 
@@ -77,6 +80,7 @@ class PhpTest extends TestCase
 			"\tpublic \$quoted = '\"stringwithquotes\"';\n" .
 			"\tpublic \$booleantrue = true;\n" .
 			"\tpublic \$booleanfalse = false;\n" .
+			"\tpublic \$nullvalue = null;\n" .
 			"\tpublic \$numericint = 42;\n" .
 			"\tpublic \$numericfloat = 3.1415;\n" .
 			"\tpublic \$section = array('key' => 'value');\n" .
@@ -101,6 +105,7 @@ class PhpTest extends TestCase
 		$object->quoted = '"stringwithquotes"';
 		$object->booleantrue = true;
 		$object->booleanfalse = false;
+		$object->nullvalue = null;
 		$object->numericint = 42;
 		$object->numericfloat = 3.1415;
 
@@ -116,6 +121,7 @@ class PhpTest extends TestCase
 			"\tpublic \$quoted = '\"stringwithquotes\"';\n" .
 			"\tpublic \$booleantrue = true;\n" .
 			"\tpublic \$booleanfalse = false;\n" .
+			"\tpublic \$nullvalue = null;\n" .
 			"\tpublic \$numericint = 42;\n" .
 			"\tpublic \$numericfloat = 3.1415;\n" .
 			"\tpublic \$section = array('key' => 'value');\n" .

--- a/src/Format/Php.php
+++ b/src/Format/Php.php
@@ -103,6 +103,9 @@ class Php implements FormatInterface
 
 			case 'boolean':
 				return $value ? 'true' : 'false';
+				
+			case 'NULL':
+				return 'null';
 		}
 	}
 

--- a/src/Format/Php.php
+++ b/src/Format/Php.php
@@ -103,7 +103,7 @@ class Php implements FormatInterface
 
 			case 'boolean':
 				return $value ? 'true' : 'false';
-				
+
 			case 'NULL':
 				return 'null';
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31679.

### Summary of Changes

Fixes invalid PHP file being generated when value is `null`.

### Testing Instructions

Run code:

    (new Joomla\Registry\Registry(['foo' => null]))->toString('Php');

Place results in PHP file. Before patch it results in invalid PHP code. After patch file is valid.

### Documentation Changes Required

No.