### PR TITLE
Add magic methods in Registry.php

### DIFF
--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -496,6 +496,46 @@ class RegistryTest extends TestCase
 	}
 
 	/**
+	 * @testdox  The object offset is correctly retrieved
+	 *
+	 * @covers   Joomla\Registry\Registry
+	 */
+	public function testGetOffsetAsAnObject()
+	{
+		$instance = new Registry(['foo' => ['bar' => 'value']]);
+
+		$this->assertSame('value', $instance->{'foo.bar'}, 'Checks a known offset.');
+		$this->assertNull($instance->{'goo.car'}, 'Checks a unknown offset.');
+	}
+
+	/**
+	 * @testdox  The object offset is correctly set
+	 *
+	 * @covers   Joomla\Registry\Registry
+	 */
+	public function testSetOffsetAsAnObject()
+	{
+		$instance = new Registry;
+
+		$instance->{'foo.bar'} = 'value';
+		$this->assertSame('value', $instance->get('foo.bar'));
+	}
+
+	/**
+	 * @testdox  The object offset is correctly removed
+	 *
+	 * @covers   Joomla\Registry\Registry
+	 */
+	public function testRemoveOffsetAsAnObject()
+	{
+		$instance = new Registry;
+		$instance->set('foo.bar', 'value');
+
+		unset($instance->{'foo.bar'});
+		$this->assertFalse(isset($instance->{'foo.bar'}));
+	}
+
+	/**
 	 * @testdox  A value is stored to the Registry
 	 *
 	 * @covers   Joomla\Registry\Registry

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -89,7 +89,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the that has been set.
 	 *
-	 * @since   2.0
+	 * @since   2.2
 	 */
 	public function __set(string $path, $value = null): void
 	{
@@ -104,7 +104,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  Value of entry or null
 	 *
-	 * @since   2.0
+	 * @since   2.2
 	 */
 	public function __get(string $path)
 	{
@@ -119,7 +119,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  boolean
 	 *
-	 * @since   2.0
+	 * @since   2.2
 	 */
 	public function __isset(string $path): bool
 	{
@@ -134,7 +134,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the removed node or null if not set
 	 *
-	 * @since   2.0
+	 * @since   2.2
 	 */
 	public function __unset(string $path): void
 	{

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -91,7 +91,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   2.0
 	 */
-	public function __set(string $path = '', $value = null): void
+	public function __set(string $path, $value = null): void
 	{
 		$this->set($path, $value);
 	}

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -89,7 +89,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the that has been set.
 	 *
-	 * @since   1.0
+	 * @since   2.0
 	 */
 	public function __set(string $path = '', $value = null): void
 	{
@@ -104,7 +104,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  Value of entry or null
 	 *
-	 * @since   1.0
+	 * @since   2.0
 	 */
 	public function __get(string $path)
 	{
@@ -119,7 +119,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  boolean
 	 *
-	 * @since   1.0
+	 * @since   2.0
 	 */
 	public function __isset(string $path): bool
 	{
@@ -134,7 +134,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the removed node or null if not set
 	 *
-	 * @since   1.6.0
+	 * @since   2.0
 	 */
 	public function __unset(string $path): void
 	{

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -89,7 +89,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the that has been set.
 	 *
-	 * @since   2.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __set(string $path, $value = null): void
 	{
@@ -104,7 +104,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  Value of entry or null
 	 *
-	 * @since   2.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __get(string $path)
 	{
@@ -119,7 +119,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  boolean
 	 *
-	 * @since   2.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __isset(string $path): bool
 	{
@@ -134,7 +134,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the removed node or null if not set
 	 *
-	 * @since   2.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __unset(string $path): void
 	{

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -89,7 +89,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the that has been set.
 	 *
-	 * @since   2.2
+	 * @since   2.1
 	 */
 	public function __set(string $path, $value = null): void
 	{
@@ -104,7 +104,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  Value of entry or null
 	 *
-	 * @since   2.2
+	 * @since   2.1
 	 */
 	public function __get(string $path)
 	{
@@ -119,7 +119,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  boolean
 	 *
-	 * @since   2.2
+	 * @since   2.1
 	 */
 	public function __isset(string $path): bool
 	{
@@ -134,7 +134,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  mixed  The value of the removed node or null if not set
 	 *
-	 * @since   2.2
+	 * @since   2.1
 	 */
 	public function __unset(string $path): void
 	{

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -93,7 +93,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 */
 	public function __set(string $path = '', $value = null): void
 	{
-		$this->set($name, $value);
+		$this->set($path, $value);
 	}
 
 	/**
@@ -108,7 +108,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 */
 	public function __get(string $path)
 	{
-		return $this->get($name);
+		return $this->get($path);
 	}
 
 	/**
@@ -123,7 +123,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 */
 	public function __isset(string $path): bool
 	{
-		return $this->exists($name);
+		return $this->exists($path);
 	}
 
 	/**
@@ -138,7 +138,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 */
 	public function __unset(string $path): void
 	{
-		$this->remove($name);
+		$this->remove($path);
 	}
 
 	/**

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -82,7 +82,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 
 	/**
 	 * Set a registry value.
-	 * Example: $registry->useProperty = 'Value'; as $registry->set('useProperty', 'Value');
+	 * Example: $registry->anyProperty = 'Value'; as $registry->set('anyProperty', 'Value');
 	 *
 	 * @param   string  $path   Registry Path (e.g. joomla.content.showauthor)
 	 * @param   mixed   $value  Value of entry

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -142,24 +142,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	}
 
 	/**
-	 * Merge a Registry object into this one
-	 * Example: $registry($object); Use as $registry->loadObject($object);
-	 * or $registry->loadArray($object); or $registry->merge($object);
-	 *
-	 * @param   Registry  $source     Source Registry object to merge.
-	 *
-	 * @return  $this
-	 *
-	 * @since   1.0
-	 */
-	public function __invoke($source): Registry
-	{
-		$this->bindData($this->data, $source);
-
-		return $this;
-	}
-
-	/**
 	 * Magic function to render this object as a string using default args of toString method.
 	 *
 	 * @return  string

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -148,6 +148,8 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @param   Registry  $source     Source Registry object to merge.
 	 *
+	 * @return  $this
+	 
 	 * @since   1.0
 	 */
 	public function __invoke($source): Registry

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -101,7 +101,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * Example: $var = $registry->anyProperty; Use as $var = $registry->get('anyProperty');
 	 *
 	 * @param   string  $path     Registry path (e.g. joomla.content.showauthor)
-	 * @param   mixed   $default  Optional default value, returned if the internal value is null.
 	 *
 	 * @return  mixed  Value of entry or null
 	 *
@@ -151,9 +150,9 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
-	public function __invoke($data): Registry
+	public function __invoke($source): Registry
 	{
-		$this->bindData($this->data, $data);
+		$this->bindData($this->data, $source);
 
 		return $this;
 	}

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -149,7 +149,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @param   Registry  $source     Source Registry object to merge.
 	 *
 	 * @return  $this
-	 
+	 *
 	 * @since   1.0
 	 */
 	public function __invoke($source): Registry

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -91,7 +91,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
-	public function __set(string $name = '', $value = null): void
+	public function __set(string $path = '', $value = null): void
 	{
 		$this->set($name, $value);
 	}
@@ -107,7 +107,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
-	public function __get(string $name)
+	public function __get(string $path)
 	{
 		return $this->get($name);
 	}
@@ -122,7 +122,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
-	public function __isset(string $name): bool
+	public function __isset(string $path): bool
 	{
 		return $this->exists($name);
 	}
@@ -137,7 +137,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.6.0
 	 */
-	public function __unset(string $name): void
+	public function __unset(string $path): void
 	{
 		$this->remove($name);
 	}

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -81,6 +81,84 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	}
 
 	/**
+	 * Set a registry value.
+	 * Example: $registry->useProperty = 'Value'; as $registry->set('useProperty', 'Value');
+	 *
+	 * @param   string  $path   Registry Path (e.g. joomla.content.showauthor)
+	 * @param   mixed   $value  Value of entry
+	 *
+	 * @return  mixed  The value of the that has been set.
+	 *
+	 * @since   1.0
+	 */
+	public function __set(string $name = '', $value = null): void
+	{
+		$this->set($name, $value);
+	}
+
+	/**
+	 * Get a registry value.
+	 * Example: $var = $registry->anyProperty; Use as $var = $registry->get('anyProperty');
+	 *
+	 * @param   string  $path     Registry path (e.g. joomla.content.showauthor)
+	 * @param   mixed   $default  Optional default value, returned if the internal value is null.
+	 *
+	 * @return  mixed  Value of entry or null
+	 *
+	 * @since   1.0
+	 */
+	public function __get(string $name)
+	{
+		return $this->get($name);
+	}
+
+	/**
+	 * Check if a registry path exists.
+	 * Example: isset($registry->anyProperty); Use as $registry->exists('anyProperty');
+	 *
+	 * @param   string  $path  Registry path (e.g. joomla.content.showauthor)
+	 *
+	 * @return  boolean
+	 *
+	 * @since   1.0
+	 */
+	public function __isset(string $name): bool
+	{
+		return $this->exists($name);
+	}
+
+	/**
+	 * Delete a registry value
+	 * Example: unset($registry->anyProperty); Use as $registry->remove('anyProperty');
+	 *
+	 * @param   string  $path  Registry Path (e.g. joomla.content.showauthor)
+	 *
+	 * @return  mixed  The value of the removed node or null if not set
+	 *
+	 * @since   1.6.0
+	 */
+	public function __unset(string $name): void
+	{
+		$this->remove($name);
+	}
+
+	/**
+	 * Merge a Registry object into this one
+	 * Example: $registry($object); Use as $registry->loadObject($object);
+	 * or $registry->loadArray($object); or $registry->merge($object);
+	 *
+	 * @param   Registry  $source     Source Registry object to merge.
+	 *
+	 * @since   1.0
+	 */
+	public function __invoke($data): Registry
+	{
+		$this->bindData($this->data, $data);
+
+		return $this;
+	}
+
+	/**
 	 * Magic function to render this object as a string using default args of toString method.
 	 *
 	 * @return  string


### PR DESCRIPTION
Add magic methods.
The Registry class is used to get data of different configurations and settings.
In the case when we want to get configuration data with a non-existent setting, we want to use the default value.
But when we use regular objects, we get a PHP error about missing a property.
And when using the Get(), Set() methods, we have to write a lot of code, the text becomes NOT susceptible to reading.

```
$array = ['id'=>123, 'name'=>'Text Button'];
$params = new Registry($array);
```
The old syntax.
`echo "<button id='" . $params->get('id') . "'>" . $params->get('name') . "</button>";`
New syntax.
**`echo "<button id='$params->id'>$params->name</button>";`**

This ability can be used in templates of modules, plugins, components.
You can see how much easier it is to write?
And much more important that such code is easier for programmers to read again.

### In the description of this class we see:
```
// Set a value in the registry.
$registry['foo'] = 'bar';

// Get a value from the registry;
$value = $registry['foo'];

// Check if a key in the registry is set.
if (isset($registry['foo']))
{
	echo 'Say bar.';
}
```

This is a similar approach.
But now we can write:
```
// Set a value in the registry.
$registry->foo = 'bar';

// Get a value from the registry;
$value = $registry->foo;

// Check if a key in the registry is set.
if (isset($registry->foo))
{
	echo 'Say bar.';
}
```