### PR TITLE
 PHP 8.1 deprecation notices.

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -100,6 +100,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @link    https://www.php.net/manual/en/countable.count.php
 	 * @since   1.3.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return \count(get_object_vars($this->data));
@@ -114,6 +115,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @since   1.0
 	 * @note    The interface is only present in PHP 5.4 and up.
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize()
 	{
 		return $this->data;
@@ -252,6 +254,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @see     IteratorAggregate::getIterator()
 	 * @since   1.3.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new \ArrayIterator($this->data);
@@ -391,6 +394,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return $this->exists($offset);
@@ -405,6 +409,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		return $this->get($offset);
@@ -420,6 +425,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
 		$this->set($offset, $value);
@@ -434,6 +440,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{
 		$this->remove($offset);


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Silencing PHP 8.1 deprecation notices that prevents Joomla! from running with error reporting on.
Example of error message:
PHP Deprecated:  Return type of Joomla\Registry\Registry::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in D:\virtualhosts\clean40\libraries\vendor\joomla\registry\src\Registry.php on line 437

Snip from PHP.net Backward Incompatible Changes:

![image](https://user-images.githubusercontent.com/25645600/145463630-66a58391-dda8-4708-907a-b8d53d591fc6.png)

### Testing Instructions
Code review or check that errors disappear from logfile.
### Documentation Changes Required
Probably not.