### PR TITLE
PHP 8.1 Deprecation notice fixes

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -123,6 +123,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @since   1.0
 	 * @note    The interface is only present in PHP 5.4 and up.
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize()
 	{
 		return $this->data;
@@ -436,6 +437,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return (boolean) ($this->get($offset) !== null);
@@ -450,6 +452,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		return $this->get($offset);
@@ -465,6 +468,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
 		$this->set($offset, $value);
@@ -479,6 +483,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{
 		$this->remove($offset);

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -109,6 +109,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @link    https://www.php.net/manual/en/countable.count.php
 	 * @since   1.3.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return \count(get_object_vars($this->data));
@@ -286,6 +287,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @see     IteratorAggregate::getIterator()
 	 * @since   1.3.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new \ArrayIterator($this->data);


### PR DESCRIPTION
Backports https://github.com/joomla-framework/registry/pull/59 to Framework v1 for CMS 3.10