### PR TITLE
Check if passed data is null

### DIFF
--- a/src/Format/Json.php
+++ b/src/Format/Json.php
@@ -51,7 +51,7 @@ class Json implements FormatInterface
 	 */
 	public function stringToObject($data, array $options = ['processSections' => false])
 	{
-		$data = trim($data);
+		$data = trim($data ?? '');
 
 		// Because developers are clearly not validating their data before pushing it into a Registry, we'll do it for them
 		if (empty($data))


### PR DESCRIPTION
Pull Request for Issue [#](https://github.com/joomla/joomla-cms/issues/37783).

### Summary of Changes
As null can be passed to make a JSON object from a string, it should be checked. This throws a warning on PHP 8.1.