### PR TITLE
Flattened registry mode

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -550,6 +550,21 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
     {
         $result = null;
 
+        if ($this->flattened) {
+            if (isset($this->data->$path)) {
+                // Can append only to array
+                if (\is_array($this->data->$path)) {
+                    $this->data->$path[] = $value;
+                } else {
+                    $this->data->$path = $value;
+                }
+            } else {
+                $this->data->$path = [$value];
+            }
+
+            return $value;
+        }
+
         /*
          * Explode the registry path into an array and remove empty
          * nodes that occur as a result of a double dot. ex: joomla..test

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -795,4 +795,23 @@ class RegistryTest extends TestCase
         $this->assertEquals('test1', $a->get('Foo/Bar'));
         $this->assertEquals('test2', $a->get('Foo/Baz'));
     }
+
+    /**
+     * @testdox  The Registry created with flattened property
+     *
+     * @covers   \Joomla\Registry\Registry
+     */
+    public function testFlattened()
+    {
+        $data = (object) [
+            'foo' => 'bar',
+            'bar' => ['beer' => true]
+        ];
+        $r = new Registry($data, true);
+        $r->set('test.set', 'test set');
+
+        $this->assertEquals('bar', $r->get('foo'));
+        $this->assertEquals(null, $r->get('bar.beer'));
+        $this->assertEquals('test set', $r->get('test.set'));
+    }
 }


### PR DESCRIPTION
### Summary of Changes

The changes should allow to use registry in Flattened mode.
This should speed up the Registry, in cases when nested access to Data does not needed.


### Testing Instructions

Unit testing passes.

### Documentation Changes Required

New parameters for Registry constructor, that enable Flattened mode.