### PR TITLE
Fix error when Registry with empty separator

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -153,7 +153,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
         }
 
         // Explode the registry path into an array
-        $nodes = \explode($this->separator, $path);
+        $nodes = $this->separator ? \explode($this->separator, $path) : [$path];
 
         // Initialize the current node to be the registry root.
         $node  = $this->data;
@@ -196,7 +196,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
             return $default;
         }
 
-        if (!\strpos($path, $this->separator)) {
+        if (!$this->separator || !\strpos($path, $this->separator)) {
             return (isset($this->data->$path) && $this->data->$path !== null && $this->data->$path !== '')
                 ? $this->data->$path
                 : $default;
@@ -461,7 +461,11 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
          * nodes that occur as a result of a double separator. ex: joomla..test
          * Finally, re-key the array so they are sequential.
          */
-        $nodes = \array_values(\array_filter(\explode($separator, $path), 'strlen'));
+        if ($separator) {
+            $nodes = \array_values(\array_filter(\explode($separator, $path), 'strlen'));
+        } else {
+            $nodes = [$path];
+        }
 
         if (!$nodes) {
             return null;
@@ -532,7 +536,11 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
          * nodes that occur as a result of a double dot. ex: joomla..test
          * Finally, re-key the array so they are sequential.
          */
-        $nodes = \array_values(\array_filter(\explode('.', $path), 'strlen'));
+        if ($this->separator) {
+            $nodes = \array_values(\array_filter(\explode($this->separator, $path), 'strlen'));
+        } else {
+            $nodes = [$path];
+        }
 
         if ($nodes) {
             // Initialize the current node to be the registry root.
@@ -582,7 +590,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
     public function remove($path)
     {
         // Cheap optimisation to direct remove the node if there is no separator
-        if (!\strpos($path, $this->separator)) {
+        if (!$this->separator || !\strpos($path, $this->separator)) {
             $result = (isset($this->data->$path) && $this->data->$path !== null && $this->data->$path !== '')
                 ? $this->data->$path
                 : null;

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -153,7 +153,11 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
         }
 
         // Explode the registry path into an array
-        $nodes = $this->separator ? \explode($this->separator, $path) : [$path];
+        if ($this->separator === null || $this->separator === '') {
+            $nodes = [$path];
+        } else {
+            $nodes = \explode($this->separator, $path);
+        }
 
         // Initialize the current node to be the registry root.
         $node  = $this->data;
@@ -196,7 +200,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
             return $default;
         }
 
-        if (!$this->separator || !\strpos($path, $this->separator)) {
+        if ($this->separator === null || $this->separator === '' || !\strpos($path, $this->separator)) {
             return (isset($this->data->$path) && $this->data->$path !== null && $this->data->$path !== '')
                 ? $this->data->$path
                 : $default;
@@ -461,10 +465,10 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
          * nodes that occur as a result of a double separator. ex: joomla..test
          * Finally, re-key the array so they are sequential.
          */
-        if ($separator) {
-            $nodes = \array_values(\array_filter(\explode($separator, $path), 'strlen'));
-        } else {
+        if ($separator === null || $separator === '') {
             $nodes = [$path];
+        } else {
+            $nodes = \array_values(\array_filter(\explode($separator, $path), 'strlen'));
         }
 
         if (!$nodes) {
@@ -536,10 +540,10 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
          * nodes that occur as a result of a double dot. ex: joomla..test
          * Finally, re-key the array so they are sequential.
          */
-        if ($this->separator) {
-            $nodes = \array_values(\array_filter(\explode($this->separator, $path), 'strlen'));
-        } else {
+        if ($this->separator === null || $this->separator === '') {
             $nodes = [$path];
+        } else {
+            $nodes = \array_values(\array_filter(\explode($this->separator, $path), 'strlen'));
         }
 
         if ($nodes) {
@@ -590,7 +594,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
     public function remove($path)
     {
         // Cheap optimisation to direct remove the node if there is no separator
-        if (!$this->separator || !\strpos($path, $this->separator)) {
+        if ($this->separator === null || $this->separator === '' || !\strpos($path, $this->separator)) {
             $result = (isset($this->data->$path) && $this->data->$path !== null && $this->data->$path !== '')
                 ? $this->data->$path
                 : null;

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -797,7 +797,7 @@ class RegistryTest extends TestCase
     }
 
     /**
-     * @testdox  The Registry operates correctly with empty separator
+     * @testdox  The Registry operates correctly with empty string separator
      *
      * @covers   \Joomla\Registry\Registry
      */
@@ -806,10 +806,44 @@ class RegistryTest extends TestCase
         $a = new Registry(['foo' => 'bar']);
         $a->separator = '';
         $a->set('bar', 'beer');
-        $a->set('foo.bar', 'beer');
+        $a->set('foo2.bar', 'beer');
 
         $this->assertEquals('bar', $a->get('foo'));
         $this->assertEquals('beer', $a->get('bar'));
-        $this->assertEquals('beer', $a->get('foo.bar'));
+        $this->assertEquals('beer', $a->get('foo2.bar'));
+    }
+
+    /**
+     * @testdox  The Registry operates correctly with null separator
+     *
+     * @covers   \Joomla\Registry\Registry
+     */
+    public function testNullSeparator()
+    {
+        $a = new Registry(['foo' => 'bar']);
+        $a->separator = null;
+        $a->set('bar', 'beer');
+        $a->set('foo2.bar', 'beer');
+
+        $this->assertEquals('bar', $a->get('foo'));
+        $this->assertEquals('beer', $a->get('bar'));
+        $this->assertEquals('beer', $a->get('foo2.bar'));
+    }
+
+    /**
+     * @testdox  The Registry operates correctly with Zero separator
+     *
+     * @covers   \Joomla\Registry\Registry
+     */
+    public function testZeroSeparator()
+    {
+        $a = new Registry(['foo' => 'bar']);
+        $a->separator = 0;
+        $a->set('bar', 'beer');
+        $a->set('foo20bar', 'beer');
+
+        $this->assertEquals('bar', $a->get('foo'));
+        $this->assertEquals('beer', $a->get('bar'));
+        $this->assertEquals((object) ['bar' => 'beer'], $a->get('foo2'));
     }
 }

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -806,11 +806,11 @@ class RegistryTest extends TestCase
         $a = new Registry(['foo' => 'bar']);
         $a->separator = '';
         $a->set('bar', 'beer');
-        $a->set('foo2.bar', 'beer');
+        $a->set('foo2.bar', 'wine');
 
         $this->assertEquals('bar', $a->get('foo'));
         $this->assertEquals('beer', $a->get('bar'));
-        $this->assertEquals('beer', $a->get('foo2.bar'));
+        $this->assertEquals('wine', $a->get('foo2.bar'));
     }
 
     /**
@@ -823,11 +823,11 @@ class RegistryTest extends TestCase
         $a = new Registry(['foo' => 'bar']);
         $a->separator = null;
         $a->set('bar', 'beer');
-        $a->set('foo2.bar', 'beer');
+        $a->set('foo2.bar', 'wine');
 
         $this->assertEquals('bar', $a->get('foo'));
         $this->assertEquals('beer', $a->get('bar'));
-        $this->assertEquals('beer', $a->get('foo2.bar'));
+        $this->assertEquals('wine', $a->get('foo2.bar'));
     }
 
     /**
@@ -840,10 +840,10 @@ class RegistryTest extends TestCase
         $a = new Registry(['foo' => 'bar']);
         $a->separator = 0;
         $a->set('bar', 'beer');
-        $a->set('foo20bar', 'beer');
+        $a->set('foo20bar', 'wine');
 
         $this->assertEquals('bar', $a->get('foo'));
         $this->assertEquals('beer', $a->get('bar'));
-        $this->assertEquals((object) ['bar' => 'beer'], $a->get('foo2'));
+        $this->assertEquals((object) ['bar' => 'wine'], $a->get('foo2'));
     }
 }

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -795,4 +795,21 @@ class RegistryTest extends TestCase
         $this->assertEquals('test1', $a->get('Foo/Bar'));
         $this->assertEquals('test2', $a->get('Foo/Baz'));
     }
+
+    /**
+     * @testdox  The Registry operates correctly with empty separator
+     *
+     * @covers   \Joomla\Registry\Registry
+     */
+    public function testEmptySeparator()
+    {
+        $a = new Registry(['foo' => 'bar']);
+        $a->separator = '';
+        $a->set('bar', 'beer');
+        $a->set('foo.bar', 'beer');
+
+        $this->assertEquals('bar', $a->get('foo'));
+        $this->assertEquals('beer', $a->get('bar'));
+        $this->assertEquals('beer', $a->get('foo.bar'));
+    }
 }


### PR DESCRIPTION
### Summary of Changes

Registry crashes when separator is empty

### Testing Instructions

Test passes

### Documentation Changes Required

Kind of bugfix
