### PR TITLE
Updating phpstan to 2.0

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,7 @@ local pipeline(name, phpversion, params) = {
                 depends: [ "composer" ],
                 failure: "ignore",
                 commands: [
-                    "vendor/bin/phpstan analyse src",
+                    "./vendor/bin/phpstan",
                 ]
             },
             {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -103,4 +103,6 @@ local pipeline(name, phpversion, params) = {
     pipeline("8.1 lowest", "8.1", "--prefer-stable --prefer-lowest"),
     pipeline("8.1", "8.1", "--prefer-stable"),
     pipeline("8.2", "8.2", "--prefer-stable"),
+    pipeline("8.3", "8.3", "--prefer-stable"),
+    pipeline("8.4", "8.4", "--prefer-stable"),
 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   image: joomlaprojects/docker-images:php8.1-ast
   name: phan
 - commands:
-  - vendor/bin/phpstan analyse src
+  - ./vendor/bin/phpstan
   depends:
   - composer
   failure: ignore

--- a/.drone.yml
+++ b/.drone.yml
@@ -110,6 +110,6 @@ volumes:
   name: composer-cache
 ---
 kind: signature
-hmac: 71012f10099a69f1e30d64935917ac6f5713a4dd83909c06182791133aa72075
+hmac: 0201171ba78a5c5ee2cf44c97eb1ca7dc6dda89cfb0ad2409ec65c0a9366e750
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -109,7 +109,48 @@ volumes:
     path: /tmp/composer-cache
   name: composer-cache
 ---
+kind: pipeline
+name: PHP 8.3
+steps:
+- commands:
+  - php -v
+  - composer update --prefer-stable
+  image: joomlaprojects/docker-images:php8.3
+  name: composer
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+- commands:
+  - vendor/bin/phpunit
+  failure: ignore
+  image: joomlaprojects/docker-images:php8.3
+  name: PHPUnit
+volumes:
+- host:
+    path: /tmp/composer-cache
+  name: composer-cache
+---
+kind: pipeline
+name: PHP 8.4
+steps:
+- commands:
+  - php -v
+  - composer update --prefer-stable
+  image: joomlaprojects/docker-images:php8.4
+  name: composer
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+- commands:
+  - vendor/bin/phpunit
+  image: joomlaprojects/docker-images:php8.4
+  name: PHPUnit
+volumes:
+- host:
+    path: /tmp/composer-cache
+  name: composer-cache
+---
 kind: signature
-hmac: 0201171ba78a5c5ee2cf44c97eb1ca7dc6dda89cfb0ad2409ec65c0a9366e750
+hmac: c80e2c4d7313a29ba7c1295605f0ecfb0ae980a6749fb4294cc9390760ef586e
 
 ...

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "symfony/yaml": "^5.0",
         "phpunit/phpunit": "^9.5.28",
         "squizlabs/php_codesniffer": "^3.7.2",
-        "phpstan/phpstan": "^1.10.7",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
         "phan/phan": "^5.4.2"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+
+includes:
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+parameters:
+	level: 5
+	phpVersion: 80100
+	reportUnmatchedIgnoredErrors: false
+	paths:
+		- src


### PR DESCRIPTION
### Summary of Changes
This updates phpstan to version 2.0, adds a configuration file for phpstan and sets the level to 5, adds the deprecation plugin to it and changes the call in drone.

### Testing Instructions
Codereview
